### PR TITLE
Adding the feature of 'contexts', including tests.

### DIFF
--- a/src/Particle/Validator/Validator.php
+++ b/src/Particle/Validator/Validator.php
@@ -4,11 +4,20 @@ namespace Particle\Validator;
 class Validator
 {
     /**
-     * @var Chain[]
+     * The default context (if no context is currently active).
+     */
+    const DEFAULT_CONTEXT = 'default';
+
+    /**
+     * Contains an array of context => Chain objects.
+     *
+     * @var array
      */
     protected $chains = [];
 
     /**
+     * Contains an array of context => messages.
+     *
      * @var MessageStack
      */
     protected $messageStack;
@@ -18,44 +27,127 @@ class Validator
      *
      * @var array
      */
-    protected $overwrites = [];
+    protected $messageOverwrites = [];
 
+    /**
+     * Construct the validator.
+     */
+    public function __construct()
+    {
+        $this->context = self::DEFAULT_CONTEXT;
+    }
+
+    /**
+     * Creates a new required Validation Chain for the key $key.
+     *
+     * @param string $key
+     * @param string|null $name
+     * @param bool $allowEmpty
+     * @return Chain
+     */
     public function required($key, $name = null, $allowEmpty = false)
     {
-        return $this->chains[$key] = new Chain($key, $name, true, $allowEmpty);
+        return $this->buildChain($key, $name, true, $allowEmpty);
     }
 
+    /**
+     * Creates a new optional Validation Chain for the key $key.
+     *
+     * @param string $key
+     * @param string|null $name
+     * @param bool $allowEmpty
+     * @return Chain
+     */
     public function optional($key, $name = null, $allowEmpty = true)
     {
-        return $this->chains[$key] = new Chain($key, $name, false, $allowEmpty);
+        return $this->buildChain($key, $name, false, $allowEmpty);
     }
 
-    public function validate(array $values)
+    /**
+     * Validates the values in the $values array and returns the result as a bool.
+     *
+     * @param array $values
+     * @param string $context
+     * @return bool
+     */
+    public function validate(array $values, $context = self::DEFAULT_CONTEXT)
     {
         $valid = true;
-        $this->messageStack = new MessageStack();
-        $this->messageStack->setMessages($this->overwrites);
+        $messageStack = $this->buildMessageStack($context);
 
-        foreach ($this->chains as $chain) {
-            $valid = $chain->validate($this->messageStack, $values) && $valid;
+        foreach ($this->chains[$context] as $chain) {
+            /** @var Chain $chain */
+            $valid = $chain->validate($messageStack, $values) && $valid;
         }
         return $valid;
     }
 
+    /**
+     * Returns an array of all validation failures.
+     *
+     * @return array
+     */
     public function getMessages()
     {
         return $this->messageStack->getMessages();
     }
 
     /**
-     * Overwrite the default messages.
+     * Create a new validation context with the closure $closure.
+     *
+     * @param string $name
+     * @param \Closure $closure
+     */
+    public function context($name, \Closure $closure)
+    {
+        $this->context = $name;
+        $closure($this);
+        $this->context = self::DEFAULT_CONTEXT;
+    }
+
+    /**
+     * Overwrite the default messages with specific messages per key.
      *
      * @param array $messages
      * @return $this
      */
     public function setMessages(array $messages)
     {
-        $this->overwrites = $messages;
+        $this->messageOverwrites[$this->context] = $messages;
         return $this;
+    }
+
+    /**
+     * Builds, stores and returns a new Chain object.
+     *
+     * @param string $key
+     * @param string $name
+     * @param bool $required
+     * @param bool $allowEmpty
+     * @return Chain
+     */
+    protected function buildChain($key, $name, $required, $allowEmpty)
+    {
+        if (isset($this->chains[$this->context][$key])) {
+            return $this->chains[$this->context][$key];
+        }
+        return $this->chains[$this->context][$key] = new Chain($key, $name, $required, $allowEmpty);
+    }
+
+    /**
+     * Build a new MessageStack, set the message overwrites and return it.
+     *
+     * @param string $context
+     * @return MessageStack
+     */
+    protected function buildMessageStack($context)
+    {
+        $this->messageStack = new MessageStack();
+
+        if (isset($this->messageOverwrites[$context])) {
+            $this->messageStack->setMessages($this->messageOverwrites[$context]);
+        }
+
+        return $this->messageStack;
     }
 }

--- a/tests/Particle/Validator/ContextTest.php
+++ b/tests/Particle/Validator/ContextTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use Particle\Validator\Context;
+use Particle\Validator\Rule;
+use Particle\Validator\Validator;
+
+class ContextTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Validator
+     */
+    protected $validator;
+
+    public function setUp()
+    {
+        $this->validator = new Validator();
+    }
+
+    public function testCanBeValidatedIndependently()
+    {
+        $this->validator->context('insert', function(Validator $context) {
+            $context->required('first_name')->length(5);
+        });
+
+        $this->validator->required('first_name')->length(3);
+
+        $result = $this->validator->validate(['first_name' => 'berry'], 'insert');
+
+        $this->assertTrue($result);
+        $this->assertEquals([], $this->validator->getMessages());
+    }
+
+    public function testCanHaveIndependentMessages()
+    {
+        $this->validator->context('insert', function (Validator $context) {
+            $context->required('first_name')->length(5);
+
+            $context->setMessages([
+                'first_name' => [
+                    Rule\Length::TOO_SHORT => 'This is from inside the context.'
+                ]
+            ]);
+        });
+
+        $this->validator->setMessages([
+            'first_name' => [
+                Rule\Length::TOO_SHORT => 'This is outside of the context',
+            ]
+        ]);
+
+        $this->validator->validate(['first_name' => 'Rick'], 'insert');
+        $expected = [
+            'first_name' => [
+                Rule\Length::TOO_SHORT => 'This is from inside the context.'
+            ]
+        ];
+        $this->assertEquals($expected, $this->validator->getMessages());
+    }
+}


### PR DESCRIPTION
With this PR, contexts are introduced to *Particle\Validator*, which means you can do stuff like the following:

```php
$v = new Validator;
$v->context('insert', function(Validator $context) {
  $context->required('first_name')->length(5);
});
$v->required('first_name')->length(4);

$v->validate(['first_name' => 'Berry'], 'insert'); // bool(true), because the context is used.
```