### PR TITLE
Adding the ability to set global default messages.

### DIFF
--- a/src/Particle/Validator/MessageStack.php
+++ b/src/Particle/Validator/MessageStack.php
@@ -4,12 +4,41 @@ namespace Particle\Validator;
 
 class MessageStack
 {
+    /**
+     * Contains a list of all validation messages.
+     *
+     * @var array
+     */
     protected $messages = [];
 
+    /**
+     * Contains an array of field and reason specific message overwrites.
+     *
+     * @var array
+     */
     protected $overwrites = [];
 
+    /**
+     * Contains an array of global message overwrites.
+     *
+     * @var array
+     */
+    protected $defaultMessages = [];
+
+    /**
+     * Will append an error message for the target $key with $reason to the stack.
+     *
+     * @param string $key
+     * @param string $reason
+     * @param string $message
+     * @param array $parameters
+     */
     public function append($key, $reason, $message, array $parameters)
     {
+        if (isset($this->defaultMessages[$reason])) {
+            $message = $this->defaultMessages[$reason];
+        }
+
         if (isset($this->overwrites[$key][$reason])) {
             $message = $this->overwrites[$key][$reason];
         }
@@ -17,9 +46,38 @@ class MessageStack
         $this->messages[$key][$reason] = $this->format($message, $parameters);
     }
 
+    /**
+     * Returns a list of all messages.
+     *
+     * @return array
+     */
     public function getMessages()
     {
         return $this->messages;
+    }
+
+    /**
+     * Overwrite key-validator specific messages (so [first_name => [Length::TOO_SHORT => 'Message']]).
+     *
+     * @param array $messages
+     * @return $this
+     */
+    public function overwriteMessages(array $messages)
+    {
+        $this->overwrites = $messages;
+        return $this;
+    }
+
+    /**
+     * Overwrite the default validator-specific messages (so [Length::TOO_SHORT => 'Generic message'].
+     *
+     * @param array $messages
+     * @return $this
+     */
+    public function overwriteDefaultMessages(array $messages)
+    {
+        $this->defaultMessages = $messages;
+        return $this;
     }
 
     /**
@@ -37,13 +95,5 @@ class MessageStack
         };
 
         return preg_replace_callback('~{{\s*([^}\s]+)\s*}}~', $replace, $message);
-    }
-
-    /**
-     * @param array $messages
-     */
-    public function setMessages(array $messages)
-    {
-        $this->overwrites = $messages;
     }
 }

--- a/src/Particle/Validator/Validator.php
+++ b/src/Particle/Validator/Validator.php
@@ -30,6 +30,13 @@ class Validator
     protected $messageOverwrites = [];
 
     /**
+     * An array containing all the default messages.
+     *
+     * @var array
+     */
+    protected $defaultMessages = [];
+
+    /**
      * Construct the validator.
      */
     public function __construct()
@@ -106,14 +113,26 @@ class Validator
     }
 
     /**
-     * Overwrite the default messages with specific messages per key.
+     * Overwrite the messages for specific keys.
      *
      * @param array $messages
      * @return $this
      */
-    public function setMessages(array $messages)
+    public function overwriteMessages(array $messages)
     {
         $this->messageOverwrites[$this->context] = $messages;
+        return $this;
+    }
+
+    /**
+     * Overwrite the default messages with custom messages.
+     *
+     * @param array $messages
+     * @return $this
+     */
+    public function overwriteDefaultMessages(array $messages)
+    {
+        $this->defaultMessages = $messages;
         return $this;
     }
 
@@ -143,9 +162,10 @@ class Validator
     protected function buildMessageStack($context)
     {
         $this->messageStack = new MessageStack();
+        $this->messageStack->overwriteDefaultMessages($this->defaultMessages);
 
         if (isset($this->messageOverwrites[$context])) {
-            $this->messageStack->setMessages($this->messageOverwrites[$context]);
+            $this->messageStack->overwriteMessages($this->messageOverwrites[$context]);
         }
 
         return $this->messageStack;

--- a/tests/Particle/Validator/ContextTest.php
+++ b/tests/Particle/Validator/ContextTest.php
@@ -35,14 +35,14 @@ class ContextTest extends PHPUnit_Framework_TestCase
         $this->validator->context('insert', function (Validator $context) {
             $context->required('first_name')->length(5);
 
-            $context->setMessages([
+            $context->overwriteMessages([
                 'first_name' => [
                     Rule\Length::TOO_SHORT => 'This is from inside the context.'
                 ]
             ]);
         });
 
-        $this->validator->setMessages([
+        $this->validator->overwriteMessages([
             'first_name' => [
                 Rule\Length::TOO_SHORT => 'This is outside of the context',
             ]

--- a/tests/Particle/Validator/MessageStackTest.php
+++ b/tests/Particle/Validator/MessageStackTest.php
@@ -51,7 +51,7 @@ class MessageChainTest extends PHPUnit_Framework_TestCase
     public function testCanOverwriteSpecificMessagesWithParameters()
     {
         $ms = new MessageStack();
-        $ms->setMessages([
+        $ms->overwriteMessages([
             'key' => [
                 'reason' => 'This is my specific message. The key was "{{key}}"'
             ]


### PR DESCRIPTION
With this PR, it becomes possible to overwrite the global default messages. The specific messages for a certain key still have precedence, however.

```php
$this->validator->overwriteDefaultMessages([
    Rule\Length::TOO_SHORT => 'This is overwritten globally.'
]);

$this->validator->required('first_name')->length(5);

$this->validator->validate(['first_name' => 'Rick']); // false
echo $this->validator->getMessages()['first_name'][Rule\Length::TOO_SHORT]; // This is overwritten globally.
```