### PR TITLE
Adding many validation rules: alpha, alnum, between and callback.

### DIFF
--- a/src/Particle/Validator/Chain.php
+++ b/src/Particle/Validator/Chain.php
@@ -60,6 +60,52 @@ class Chain
     }
 
     /**
+     * Validate the value to consist only out of alphanumeric characters.
+     *
+     * @param bool $allowWhitespace
+     * @return Chain
+     */
+    public function alnum($allowWhitespace = false)
+    {
+        return $this->addRule(new Rule\Alnum($allowWhitespace));
+    }
+
+    /**
+     * Validate that the value only consists our of alphabetic characters.
+     *
+     * @param bool $allowWhitespace
+     * @return Chain
+     */
+    public function alpha($allowWhitespace = false)
+    {
+        return $this->addRule(new Rule\Alpha($allowWhitespace));
+    }
+
+    /**
+     * Validate that the value is between $min and $max (inclusive by default).
+     *
+     * @param int $min
+     * @param int $max
+     * @param bool $inclusive
+     * @return Chain
+     */
+    public function between($min, $max, $inclusive = true)
+    {
+        return $this->addRule(new Rule\Between($min, $max, $inclusive));
+    }
+
+    /**
+     * Validate by executing a callback function, and returning its result.
+     *
+     * @param callable $callable
+     * @return Chain
+     */
+    public function callback(callable $callable)
+    {
+        return $this->addRule(new Rule\Callback($callable));
+    }
+
+    /**
      * Validate the value to be of precisely length $length.
      *
      * @param int $length

--- a/src/Particle/Validator/Chain.php
+++ b/src/Particle/Validator/Chain.php
@@ -106,6 +106,17 @@ class Chain
     }
 
     /**
+     * Validates that the value is a date. If format is passed, it *must* be in that format.
+     *
+     * @param string|null $format
+     * @return Chain
+     */
+    public function datetime($format = null)
+    {
+        return $this->addRule(new Rule\Datetime($format));
+    }
+
+    /**
      * Validate the value to be of precisely length $length.
      *
      * @param int $length

--- a/src/Particle/Validator/Chain.php
+++ b/src/Particle/Validator/Chain.php
@@ -184,6 +184,27 @@ class Chain
     }
 
     /**
+     * Validates that the value matches the regular expression $regex.
+     *
+     * @param string $regex
+     * @return Chain
+     */
+    public function regex($regex)
+    {
+        return $this->addRule(new Rule\Regex($regex));
+    }
+
+    /**
+     * Validates that the value is a valid URL.
+     *
+     * @return Chain
+     */
+    public function url()
+    {
+        return $this->addRule(new Rule\Url());
+    }
+
+    /**
      * Set a callable which may be used to alter the required requirement on validation time.
      *
      * This may be incredibly helpful when doing conditional validation.
@@ -193,8 +214,7 @@ class Chain
      */
     public function required(callable $callback)
     {
-        $this->rules[0]->setRequired($callback);
-
+        $this->getRequiredRule()->setRequired($callback);
         return $this;
     }
 
@@ -208,7 +228,7 @@ class Chain
      */
     public function allowEmpty(callable $callback)
     {
-        $this->rules[0]->setAllowEmpty($callback);
+        $this->getRequiredRule()->setAllowEmpty($callback);
         return $this;
     }
 
@@ -246,5 +266,15 @@ class Chain
         $this->rules[] = $rule;
 
         return $this;
+    }
+
+    /**
+     * Returns the first rule, which is always the required rule.
+     *
+     * @return Rule\Required
+     */
+    protected function getRequiredRule()
+    {
+        return $this->rules[0];
     }
 }

--- a/src/Particle/Validator/Chain.php
+++ b/src/Particle/Validator/Chain.php
@@ -127,6 +127,15 @@ class Chain
     }
 
     /**
+     * Validates that the value is a valid email address (format only).
+     * @return Chain
+     */
+    public function email()
+    {
+        return $this->addRule(new Rule\Email());
+    }
+
+    /**
      * Validate the value to be of precisely length $length.
      *
      * @param int $length

--- a/src/Particle/Validator/Chain.php
+++ b/src/Particle/Validator/Chain.php
@@ -171,6 +171,19 @@ class Chain
     }
 
     /**
+     * Validates that the length of the value is between $min and $max. Inclusive is the default.
+     *
+     * @param int $min
+     * @param int $max
+     * @param bool $inclusive
+     * @return Chain
+     */
+    public function lengthBetween($min, $max, $inclusive = true)
+    {
+        return $this->addRule(new Rule\LengthBetween($min, $max, $inclusive));
+    }
+
+    /**
      * Set a callable which may be used to alter the required requirement on validation time.
      *
      * This may be incredibly helpful when doing conditional validation.

--- a/src/Particle/Validator/Chain.php
+++ b/src/Particle/Validator/Chain.php
@@ -117,6 +117,16 @@ class Chain
     }
 
     /**
+     * Validates that all characters of the value are decimal digits.
+     *
+     * @return Chain
+     */
+    public function digits()
+    {
+        return $this->addRule(new Rule\Digits());
+    }
+
+    /**
      * Validate the value to be of precisely length $length.
      *
      * @param int $length

--- a/src/Particle/Validator/Chain.php
+++ b/src/Particle/Validator/Chain.php
@@ -136,6 +136,17 @@ class Chain
     }
 
     /**
+     * Validates that the value is equal to $value.
+     *
+     * @param string $value
+     * @return Chain
+     */
+    public function equals($value)
+    {
+        return $this->addRule(new Rule\Equal($value));
+    }
+
+    /**
      * Validate the value to be of precisely length $length.
      *
      * @param int $length

--- a/src/Particle/Validator/Chain.php
+++ b/src/Particle/Validator/Chain.php
@@ -147,6 +147,19 @@ class Chain
     }
 
     /**
+     * Validates that the value is in the array with optional "loose" checking.
+     *
+     * @param array $array
+     * @param bool $strict
+     *
+     * @return Chain
+     */
+    public function inArray(array $array, $strict = true)
+    {
+        return $this->addRule(new Rule\InArray($array, $strict));
+    }
+
+    /**
      * Validate the value to be of precisely length $length.
      *
      * @param int $length

--- a/src/Particle/Validator/Exception/InvalidValueException.php
+++ b/src/Particle/Validator/Exception/InvalidValueException.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/validator/blob/master/LICENSE New BSD License
+ */
+namespace Particle\Validator\Exception;
+
+use Particle\Validator\ExceptionInterface;
+
+/**
+ * The invalid value exception is used by a callback to provide custom errors.
+ *
+ * @package Particle\Validator
+ */
+class InvalidValueException extends \Exception implements ExceptionInterface
+{
+    /**
+     * @var string
+     */
+    protected $identifier;
+
+    /**
+     * @var string
+     */
+    protected $message;
+
+    /**
+     * @param string $message
+     * @param int $identifier
+     * @param \Exception $previous
+     */
+    public function __construct($message, $identifier, \Exception $previous = null)
+    {
+        $this->message = $message;
+        $this->identifier = $identifier;
+
+        parent::__construct($message, 0, $previous);
+    }
+
+    /**
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+}

--- a/src/Particle/Validator/ExceptionInterface.php
+++ b/src/Particle/Validator/ExceptionInterface.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/validator/blob/master/LICENSE New BSD License
+ */
+namespace Particle\Validator;
+
+/**
+ * The ExceptionInterface is here to be able to catch *all* exceptions of Particle\Validator.
+ *
+ * @package Particle\Validator
+ */
+interface ExceptionInterface {
+}

--- a/src/Particle/Validator/Rule/Alnum.php
+++ b/src/Particle/Validator/Rule/Alnum.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/validator/blob/master/LICENSE New BSD License
+ */
+namespace Particle\Validator\Rule;
+
+use Particle\Validator\Rule;
+
+/**
+ * This rule checks if the value consists solely out of alphanumeric characters.
+ *
+ * @package Particle\Validator\Rule
+ */
+class Alnum extends Rule
+{
+    /**
+     * A constant that will be used for the error message when the value is not alphanumeric.
+     */
+    const NOT_ALNUM = 'Alnum::NOT_ALNUM';
+
+    /**
+     * The message templates which can be returned by this validator.
+     *
+     * @var array
+     */
+    protected $messageTemplates = [
+        self::NOT_ALNUM => 'The value of "{{ name }}" can only consist out of numeric and alphabetic characters'
+    ];
+
+    /**
+     * Indicates whether or not this rule should accept spaces.
+     *
+     * @var bool
+     */
+    protected $allowSpaces;
+
+    /**
+     * Construct the validation rule.
+     *
+     * @param bool $allowSpaces
+     */
+    public function __construct($allowSpaces)
+    {
+        $this->allowSpaces = (bool) $allowSpaces;
+    }
+
+    /**
+     * Checks whether $value consists solely out of alphanumeric characters.
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function validate($value)
+    {
+        $pattern = $this->allowSpaces ? '~^[\p{L}0-9\s]*~iu' : '~^[\p{L}0-9]*$~iu';
+
+        if (preg_match($pattern, $value) === 0) {
+            return $this->error(self::NOT_ALNUM);
+        }
+        return true;
+    }
+}

--- a/src/Particle/Validator/Rule/Alpha.php
+++ b/src/Particle/Validator/Rule/Alpha.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/validator/blob/master/LICENSE New BSD License
+ */
+namespace Particle\Validator\Rule;
+
+use Particle\Validator\Rule;
+
+/**
+ * This rule checks if the value consists solely out of alphabetic characters.
+ *
+ * @package Particle\Validator\Rule
+ */
+class Alpha extends Rule
+{
+    /**
+     * A constant that will be used for the error message when the value contains non-alphabetic characters.
+     */
+    const NOT_ALPHA = 'Alpha::NOT_ALPHA';
+
+    /**
+     * The message templates which can be returned by this validator.
+     *
+     * @var array
+     */
+    protected $messageTemplates = [
+        self::NOT_ALPHA => 'The value of "{{ name }}" can only consist out of alphabetic characters'
+    ];
+
+    /**
+     * @var bool
+     */
+    protected $allowWhitespace;
+
+    /**
+     * Construct the Alpha rule.
+     *
+     * @param bool $allowWhitespace
+     */
+    public function __construct($allowWhitespace)
+    {
+        $this->allowWhitespace = (bool) $allowWhitespace;
+    }
+
+    /**
+     * Checks whether $value consists solely out of alphabetic characters.
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function validate($value)
+    {
+        $regex = $this->allowWhitespace ? '~^[\p{L}\s]*$~iu' : '~^[\p{L}]*$~ui';
+
+        if (preg_match($regex, $value) === 0) {
+            return $this->error(self::NOT_ALPHA);
+        }
+        return true;
+    }
+}

--- a/src/Particle/Validator/Rule/Between.php
+++ b/src/Particle/Validator/Rule/Between.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/validator/blob/master/LICENSE New BSD License
+ */
+namespace Particle\Validator\Rule;
+
+use Particle\Validator\Rule;
+
+/**
+ * This rule will validate a value to be between min and max.
+ *
+ * @package Particle\Validator\Rule
+ */
+class Between extends Rule
+{
+    /**
+     * A constant for an error message if the value is not between min and max.
+     */
+    const NOT_BETWEEN = 'Between::NOT_BETWEEN';
+
+    /**
+     * The message templates which can be returned by this validator.
+     *
+     * @var array
+     */
+    protected $messageTemplates = [
+        self::NOT_BETWEEN => 'Value of "{{ name }}" must be between {{ min }} and {{ max }}'
+    ];
+
+    /**
+     * The lower boundary.
+     *
+     * @var int
+     */
+    protected $min;
+
+    /**
+     * The upper boundary.
+     *
+     * @var int
+     */
+    protected $max;
+
+    /**
+     * @var bool
+     */
+    protected $inclusive;
+
+    /**
+     * Construct the Between rule.
+     *
+     * @param int $min
+     * @param int $max
+     * @param bool $inclusive
+     */
+    public function __construct($min, $max, $inclusive = true)
+    {
+        $this->min = $min;
+        $this->max = $max;
+        $this->inclusive = (bool) $inclusive;
+    }
+
+    /**
+     * Checks whether or not $value is between min and max for this rule.
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function validate($value)
+    {
+        // inclusive
+        if ($this->inclusive && $value >= $this->min && $value <= $this->max) {
+            return true;
+        }
+        // exclusive
+        if ($value > $this->min && $value < $this->max) {
+            return true;
+        }
+        return $this->error(self::NOT_BETWEEN);
+    }
+
+    /**
+     * Returns the parameters that may be used in a validation message.
+     *
+     * @return array
+     */
+    protected function getMessageParameters()
+    {
+        return array_merge(parent::getMessageParameters(), [
+            'min' => $this->min,
+            'max' => $this->max
+        ]);
+    }
+}

--- a/src/Particle/Validator/Rule/Callback.php
+++ b/src/Particle/Validator/Rule/Callback.php
@@ -71,6 +71,13 @@ class Callback extends Rule
         }
     }
 
+    /**
+     * Validates the value according to this rule, and returns the result as a bool.
+     *
+     * @param string $key
+     * @param array $values
+     * @return bool
+     */
     public function isValid($key, array $values)
     {
         $this->values = $values;

--- a/src/Particle/Validator/Rule/Callback.php
+++ b/src/Particle/Validator/Rule/Callback.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/validator/blob/master/LICENSE New BSD License
+ */
+namespace Particle\Validator\Rule;
+
+use Particle\Validator\Exception\InvalidValueException;
+use Particle\Validator\Rule;
+
+/**
+ * This rule is for validating a value with a custom callback.
+ *
+ * @package Particle\Validator\Rule
+ */
+class Callback extends Rule
+{
+    /**
+     * A constant that will be used to indicate that the callback returned false.
+     */
+    const INVALID_VALUE = 'Callback::INVALID_VALUE';
+
+    /**
+     * The message templates which can be returned by this validator.
+     *
+     * @var array
+     */
+    protected $messageTemplates = [
+        self::INVALID_VALUE => 'The value of "{{ name }}" is invalid',
+    ];
+
+    /**
+     * @var callable
+     */
+    protected $callback;
+
+    /**
+     * Construct the Callback validator.
+     *
+     * @param callable $callback
+     */
+    public function __construct(callable $callback)
+    {
+        $this->callback = $callback;
+    }
+
+    /**
+     * Validates $value by calling the callback.
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function validate($value)
+    {
+        try {
+            $result = call_user_func($this->callback, $value, $this->values);
+
+            if ($result === true) {
+                return true;
+            }
+            return $this->error(self::INVALID_VALUE);
+        }
+        catch (InvalidValueException $exception) {
+            $reason = $exception->getIdentifier();
+            $this->messageTemplates[$reason] = $exception->getMessage();
+
+            return $this->error($reason);
+        }
+    }
+
+    public function isValid($key, array $values)
+    {
+        $this->values = $values;
+        return parent::isValid($key, $values);
+    }
+}

--- a/src/Particle/Validator/Rule/Datetime.php
+++ b/src/Particle/Validator/Rule/Datetime.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/validator/blob/master/LICENSE New BSD License
+ */
+namespace Particle\Validator\Rule;
+
+use Particle\Validator\Rule;
+
+/**
+ * This Rule is for validating a date/time.
+ *
+ * @package Particle\Validator\Rule
+ */
+class Datetime extends Rule
+{
+    /**
+     * A constant that will be used when an invalid date/time is passed.
+     */
+    const INVALID_VALUE = 'DateTime::INVALID_VALUE';
+
+    /**
+     * The message templates which can be returned by this validator.
+     *
+     * @var array
+     */
+    protected $messageTemplates = [
+        self::INVALID_VALUE => 'The value of "{{ name }}" is not a valid date',
+    ];
+
+    /**
+     * @var string
+     */
+    protected $format;
+
+    /**
+     * Construct the Datetime validator.
+     *
+     * @param string $format
+     */
+    public function __construct($format = null)
+    {
+        $this->format = $format;
+    }
+
+    /**
+     * Validates if $value is in the correct date / time format and that it's a valid date.
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function validate($value)
+    {
+        if (!($this->datetime($value, $this->format) instanceof \DateTime)) {
+            return $this->error(self::INVALID_VALUE);
+        }
+        return true;
+    }
+
+    /**
+     * Takes $value and $format and attempts to build a valid DateTime object with it.
+     *
+     * @param string $value
+     * @param string $format
+     * @return \DateTime
+     */
+    protected function datetime($value, $format = null)
+    {
+        if ($format === null) {
+            return @date_create($value);
+        }
+        return @date_create_from_format($format, $value);
+    }
+}

--- a/src/Particle/Validator/Rule/Digits.php
+++ b/src/Particle/Validator/Rule/Digits.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/validator/blob/master/LICENSE New BSD License
+ */
+namespace Particle\Validator\Rule;
+
+use Particle\Validator\Rule;
+
+/**
+ * This rule is for validating if a string consists out of only digits.
+ *
+ * @package Particle\Validator\Rule
+ */
+class Digits extends Rule
+{
+    /**
+     * A constant that will be used when the value contains things other than digits.
+     */
+    const NOT_DIGITS = 'Digits::NOT_DIGITS';
+
+    /**
+     * The message templates which can be returned by this validator.
+     *
+     * @var array
+     */
+    protected $messageTemplates = [
+        self::NOT_DIGITS => 'The value of "{{ name }}" must consist only out of digits',
+    ];
+
+    /**
+     * Validates if each character in $value is a decimal digit.
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function validate($value)
+    {
+        if (ctype_digit((string) $value)) {
+            return true;
+        }
+        return $this->error(self::NOT_DIGITS);
+    }
+}

--- a/src/Particle/Validator/Rule/Email.php
+++ b/src/Particle/Validator/Rule/Email.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/validator/blob/master/LICENSE New BSD License
+ */
+namespace Particle\Validator\Rule;
+
+use Particle\Validator\Rule;
+
+/**
+ * This rule is for validating if a value is a valid e-mail address.
+ *
+ * @package Particle\Validator\Rule
+ */
+class Email extends Rule
+{
+    /**
+     * A constant that will be used when the value contains things other than digits.
+     */
+    const INVALID_FORMAT = 'Email::INVALID_VALUE';
+
+    /**
+     * The message templates which can be returned by this validator.
+     *
+     * @var array
+     */
+    protected $messageTemplates = [
+        self::INVALID_FORMAT => 'The value of "{{ name }}" must be a valid email address',
+    ];
+
+    /**
+     * Validates if the value is a valid email address.
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function validate($value)
+    {
+        if (filter_var($value, FILTER_VALIDATE_EMAIL) !== false) {
+            return true;
+        }
+        return $this->error(self::INVALID_FORMAT);
+    }
+}

--- a/src/Particle/Validator/Rule/Equal.php
+++ b/src/Particle/Validator/Rule/Equal.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/validator/blob/master/LICENSE New BSD License
+ */
+namespace Particle\Validator\Rule;
+
+use Particle\Validator\Rule;
+
+/**
+ * This rule is for validating if a value being validated equals another value.
+ *
+ * @package Particle\Validator\Rule
+ */
+class Equal extends Rule
+{
+    /**
+     * A constant that will be used when the value is not equal to the expected value.
+     */
+    const NOT_EQUAL = 'Equal::NOT_EQUAL';
+
+    /**
+     * The message templates which can be returned by this validator.
+     *
+     * @var array
+     */
+    protected $messageTemplates = [
+        self::NOT_EQUAL => 'The value of "{{ name }}" must be equal to "{{ testvalue }}"'
+    ];
+
+    /**
+     * @var mixed
+     */
+    protected $value;
+
+    /**
+     * Construct the equal validator.
+     *
+     * @param mixed $value
+     */
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * Validates if each character in $value is a decimal digit.
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function validate($value)
+    {
+        if ($this->value === $value) {
+            return true;
+        }
+        return $this->error(self::NOT_EQUAL);
+    }
+
+    /**
+     * Returns the parameters that may be used in a validation message.
+     *
+     * @return array
+     */
+    protected function getMessageParameters()
+    {
+        return array_merge(parent::getMessageParameters(), [
+            'testvalue' => $this->value
+        ]);
+    }
+}

--- a/src/Particle/Validator/Rule/InArray.php
+++ b/src/Particle/Validator/Rule/InArray.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/validator/blob/master/LICENSE New BSD License
+ */
+namespace Particle\Validator\Rule;
+
+use Particle\Validator\Rule;
+
+/**
+ * This rule is for validating if a value is in an array.
+ *
+ * @package Particle\Validator\Rule
+ */
+class InArray extends Rule
+{
+    /**
+     * A constant that will be used when the value is not in the array without strict checking.
+     */
+    const NOT_IN_ARRAY = 'InArray::NOT_IN_ARRAY';
+
+    /**
+     * The message templates which can be returned by this validator.
+     *
+     * @var array
+     */
+    protected $messageTemplates = [
+        self::NOT_IN_ARRAY => 'The value of "{{ name }}" is not in the defined set of values',
+    ];
+
+    protected $array = [];
+
+    /**
+     * @var bool
+     */
+    protected $strict;
+
+    /**
+     * Construct the InArray rule.
+     *
+     * @param array $array
+     * @param bool $strict
+     */
+    public function __construct(array $array, $strict = true)
+    {
+        $this->array = $array;
+        $this->strict = $strict;
+    }
+
+    /**
+     * Validates if $value is in the predefined array.
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function validate($value)
+    {
+        if (in_array($value, $this->array, $this->strict)) {
+            return true;
+        }
+        return $this->error(self::NOT_IN_ARRAY);
+    }
+
+    /**
+     * Returns the parameters that may be used in a validation message.
+     *
+     * @return array
+     */
+    protected function getMessageParameters()
+    {
+        $quote = function($value) {
+            return '"' . $value . '"';
+        };
+
+        return array_merge(parent::getMessageParameters(), [
+            'values' => implode(', ', array_map($quote, $this->array))
+        ]);
+    }
+}

--- a/src/Particle/Validator/Rule/Length.php
+++ b/src/Particle/Validator/Rule/Length.php
@@ -11,7 +11,7 @@ namespace Particle\Validator\Rule;
 use Particle\Validator\Rule;
 
 /**
- * This rule is for validating the exact lenght of a string.
+ * This rule is for validating the exact length of a string.
  *
  * @package Particle\Validator\Rule
  */
@@ -59,7 +59,8 @@ class Length extends Rule
 
         if ($actualLength > $this->length) {
             return $this->error(self::TOO_LONG);
-        } elseif ($actualLength < $this->length) {
+        }
+        if ($actualLength < $this->length) {
             return $this->error(self::TOO_SHORT);
         }
         return true;

--- a/src/Particle/Validator/Rule/LengthBetween.php
+++ b/src/Particle/Validator/Rule/LengthBetween.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/validator/blob/master/LICENSE New BSD License
+ */
+namespace Particle\Validator\Rule;
+
+use Particle\Validator\Rule;
+
+/**
+ * This rule is for validating that the length of the value is within predefined boundaries.
+ *
+ * @package Particle\Validator\Rule
+ */
+class LengthBetween extends Rule
+{
+    /**
+     * A constant that is used when the value is too long.
+     */
+    const TOO_LONG = 'LengthBetween::TOO_LONG';
+
+    /**
+     * A constant that is used when the value is too short.
+     */
+    const TOO_SHORT = 'LengthBetween::TOO_SHORT';
+
+    /**
+     * The message templates which can be returned by this validator.
+     *
+     * @var array
+     */
+    protected $messageTemplates = [
+        self::TOO_LONG => 'The length of "{{ name }}" is too long, must be shorter than {{ max }} characters',
+        self::TOO_SHORT => 'The length of "{{ name }}" is too short, must be longer than {{ min}} characters'
+    ];
+
+    /**
+     * The upper boundary for the length of the value.
+     *
+     * @var int
+     */
+    protected $max;
+
+    /**
+     * The lower boundary for the length of the value.
+     *
+     * @var int
+     */
+    protected $min;
+
+    /**
+     * Whether or not the min and max length are inclusive.
+     *
+     * @var bool
+     */
+    protected $inclusive;
+
+    /**
+     * @param int $min
+     * @param int $max
+     * @param bool $inclusive
+     */
+    public function __construct($min, $max, $inclusive = true)
+    {
+        $this->min = $min;
+        $this->max = $max;
+        $this->inclusive = $inclusive;
+    }
+
+    /**
+     * Validates that the length of the value is between min and max.
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function validate($value)
+    {
+        $length = strlen($value);
+
+        if (($this->inclusive && $length > $this->max) || (!$this->inclusive && $length >= $this->max)) {
+            return $this->error(self::TOO_LONG);
+        }
+
+        if (($this->inclusive && $length < $this->min) || (!$this->inclusive && $length <= $this->min)) {
+            return $this->error(self::TOO_SHORT);
+        }
+        return true;
+    }
+
+    /**
+     * Returns the parameters that may be used in a validation message.
+     *
+     * @return array
+     */
+    protected function getMessageParameters()
+    {
+        return array_merge(parent::getMessageParameters(), [
+            'min' => $this->min,
+            'max' => $this->max
+        ]);
+    }
+}

--- a/src/Particle/Validator/Rule/Regex.php
+++ b/src/Particle/Validator/Rule/Regex.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/validator/blob/master/LICENSE New BSD License
+ */
+namespace Particle\Validator\Rule;
+
+use Particle\Validator\Rule;
+
+/**
+ * This rule is for validating that the value matches a certain regex.
+ *
+ * @package Particle\Validator\Rule
+ */
+class Regex extends Rule
+{
+    /**
+     * A constant that will be used when the value doesn't match the regex.
+     */
+    const NO_MATCH = 'Regex::NO_MATCH';
+
+    /**
+     * The message templates which can be returned by this validator.
+     *
+     * @var array
+     */
+    protected $messageTemplates = [
+        self::NO_MATCH => 'The value of "{{ name }}" is invalid'
+    ];
+
+    /**
+     * The regex that should be matched.
+     *
+     * @var string
+     */
+    protected $regex;
+
+    /**
+     * Construct the Regex rule.
+     *
+     * @param string $regex
+     */
+    public function __construct($regex)
+    {
+        $this->regex = $regex;
+    }
+
+    /**
+     * Validates that the value matches the predefined regex.
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function validate($value)
+    {
+        $result = preg_match($this->regex, $value);
+
+        if ($result === 0) {
+            return $this->error(self::NO_MATCH);
+        }
+
+        return true;
+    }
+}

--- a/src/Particle/Validator/Rule/Url.php
+++ b/src/Particle/Validator/Rule/Url.php
@@ -11,16 +11,16 @@ namespace Particle\Validator\Rule;
 use Particle\Validator\Rule;
 
 /**
- * This rule is for validating if a value is a valid e-mail address.
+ * This rule is for validating if a the value is a valid URL.
  *
  * @package Particle\Validator\Rule
  */
-class Email extends Rule
+class Url extends Rule
 {
     /**
-     * A constant that will be used when the value is not a valid e-mail address.
+     * A constant that will be used if the value is not a valid URL.
      */
-    const INVALID_FORMAT = 'Email::INVALID_VALUE';
+    const INVALID_URL = 'Url::INVALID_URL';
 
     /**
      * The message templates which can be returned by this validator.
@@ -28,20 +28,22 @@ class Email extends Rule
      * @var array
      */
     protected $messageTemplates = [
-        self::INVALID_FORMAT => 'The value of "{{ name }}" must be a valid email address',
+        self::INVALID_URL => 'The value of "{{ name }}" must be a valid URL.'
     ];
 
     /**
-     * Validates if the value is a valid email address.
+     * Validates if the value is a valid URL.
      *
      * @param mixed $value
      * @return bool
      */
     public function validate($value)
     {
-        if (filter_var($value, FILTER_VALIDATE_EMAIL) !== false) {
+        $url = filter_var($value, FILTER_VALIDATE_URL);
+
+        if ($url !== false) {
             return true;
         }
-        return $this->error(self::INVALID_FORMAT);
+        return $this->error(self::INVALID_URL);
     }
 }

--- a/tests/Particle/Validator/Rule/AlnumTest.php
+++ b/tests/Particle/Validator/Rule/AlnumTest.php
@@ -1,0 +1,102 @@
+<?php
+use Particle\Validator\Rule\Alnum;
+use Particle\Validator\Validator;
+
+class AlnumTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Validator
+     */
+    protected $validator;
+
+    public function setUp()
+    {
+        $this->validator = new Validator();
+    }
+
+    /**
+     * @dataProvider getAlphanumericWithoutSpaces
+     * @param $value
+     */
+    public function testReturnsTrueForValidValues($value)
+    {
+        $this->validator->required('first_name')->alnum();
+        $result = $this->validator->validate(['first_name' => $value]);
+
+        $this->assertTrue($result);
+        $this->assertEquals([], $this->validator->getMessages());
+    }
+
+    /**
+     * @dataProvider getAlphanumericWithSpaces
+     * @param $value
+     */
+    public function testReturnsTrueForValidValuesWithSpaces($value)
+    {
+        $this->validator->required('first_name')->alnum(true);
+        $result = $this->validator->validate(['first_name' => $value]);
+
+        $this->assertTrue($result);
+        $this->assertEquals([], $this->validator->getMessages());
+    }
+
+    /**
+     * @dataProvider getAlphanumericWithAccents
+     * @param $value
+     */
+    public function testReturnsTrueForDifferentAlphabets($value)
+    {
+        $this->validator->required('first_name')->alnum(true);
+        $result = $this->validator->validate(['first_name' => $value]);
+
+        $this->assertTrue($result);
+        $this->assertEquals([], $this->validator->getMessages());
+    }
+
+    /**
+     * @dataProvider getAlphanumericWithSpaces
+     * @param $value
+     */
+    public function testReturnsFalseForValuesWithSpaces($value, $errorReason)
+    {
+        $this->validator->required('first_name')->alnum();
+        $result = $this->validator->validate(['first_name' => $value]);
+
+        $expected = ['first_name' => [$errorReason => $this->getMessage($errorReason)]];
+
+        $this->assertFalse($result);
+        $this->assertEquals($expected, $this->validator->getMessages());
+    }
+
+    public function getAlphanumericWithoutSpaces()
+    {
+        return [
+            ['alphanumeric1337'],
+            ['1337alphanumerictoo']
+        ];
+    }
+
+    public function getAlphanumericWithSpaces()
+    {
+        return [
+            ['alphanumeric 1337', Alnum::NOT_ALNUM],
+            ['1337 this is alpha numeric', Alnum::NOT_ALNUM]
+        ];
+    }
+
+    public function getAlphanumericWithAccents()
+    {
+        return [
+            ['Björk']
+        ];
+    }
+
+    public function getMessage($reason)
+    {
+        $messages = [
+            Alnum::NOT_ALNUM => 'The value of "first name" can only consist out of numeric and alphabetic characters'
+        ];
+
+        return $messages[$reason];
+    }
+}

--- a/tests/Particle/Validator/Rule/AlphaTest.php
+++ b/tests/Particle/Validator/Rule/AlphaTest.php
@@ -1,0 +1,102 @@
+<?php
+use Particle\Validator\Rule\Alpha;
+use Particle\Validator\Validator;
+
+class AlphaTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Validator
+     */
+    protected $validator;
+
+    public function setUp()
+    {
+        $this->validator = new Validator();
+    }
+
+    /**
+     * @dataProvider getAlphaWithoutSpaces
+     * @param $value
+     */
+    public function testReturnsTrueForValidValues($value)
+    {
+        $this->validator->required('first_name')->alpha();
+        $result = $this->validator->validate(['first_name' => $value]);
+
+        $this->assertTrue($result);
+        $this->assertEquals([], $this->validator->getMessages());
+    }
+
+    /**
+     * @dataProvider getAlphaWithSpaces
+     * @param $value
+     */
+    public function testReturnsTrueForValidValuesWithSpaces($value)
+    {
+        $this->validator->required('first_name')->alpha(true);
+        $result = $this->validator->validate(['first_name' => $value]);
+
+        $this->assertTrue($result);
+        $this->assertEquals([], $this->validator->getMessages());
+    }
+
+    /**
+     * @dataProvider getAlphaWithAccents
+     * @param $value
+     */
+    public function testReturnsTrueForDifferentAlphabets($value)
+    {
+        $this->validator->required('first_name')->alpha(true);
+        $result = $this->validator->validate(['first_name' => $value]);
+
+        $this->assertTrue($result);
+        $this->assertEquals([], $this->validator->getMessages());
+    }
+
+    /**
+     * @dataProvider getAlphaWithSpaces
+     * @param $value
+     */
+    public function testReturnsFalseForValuesWithSpaces($value, $errorReason)
+    {
+        $this->validator->required('first_name')->alpha();
+        $result = $this->validator->validate(['first_name' => $value]);
+
+        $expected = ['first_name' => [$errorReason => $this->getMessage($errorReason)]];
+
+        $this->assertFalse($result);
+        $this->assertEquals($expected, $this->validator->getMessages());
+    }
+
+    public function getAlphaWithoutSpaces()
+    {
+        return [
+            ['onlyalphabet'],
+            ['alphabetagamma']
+        ];
+    }
+
+    public function getAlphaWithSpaces()
+    {
+        return [
+            ['alpha checks for alphabetical characters', Alpha::NOT_ALPHA],
+            ['this is alpha numeric too', Alpha::NOT_ALPHA]
+        ];
+    }
+
+    public function getAlphaWithAccents()
+    {
+        return [
+            ['Björk']
+        ];
+    }
+
+    public function getMessage($reason)
+    {
+        $messages = [
+            Alpha::NOT_ALPHA => 'The value of "first name" can only consist out of alphabetic characters',
+        ];
+
+        return $messages[$reason];
+    }
+}

--- a/tests/Particle/Validator/Rule/BetweenTest.php
+++ b/tests/Particle/Validator/Rule/BetweenTest.php
@@ -1,0 +1,86 @@
+<?php
+use Particle\Validator\Rule\Between;
+use Particle\Validator\Validator;
+
+class BetweenTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Validator
+     */
+    protected $validator;
+
+    public function setUp()
+    {
+        $this->validator = new Validator();
+    }
+
+    public function testReturnsTrueForValuesBetweenMinAndMax()
+    {
+        $this->validator->required('number')->between(1, 10);
+        $result = $this->validator->validate(['number' => 5]);
+
+        $this->assertTrue($result);
+        $this->assertEquals([], $this->validator->getMessages());
+    }
+
+    public function testValidatesInclusiveByDefault()
+    {
+        $this->validator->required('number')->between(1, 10);
+        $result = $this->validator->validate(['number' => 1]);
+
+        $this->assertTrue($result);
+        $this->assertEquals([], $this->validator->getMessages());
+    }
+
+    public function testValidatesExclusiveOnRequest()
+    {
+        $this->validator->required('number')->between(1, 10, false);
+        $result = $this->validator->validate(['number' => 1]);
+
+        $expected = [
+            'number' => [
+                Between::NOT_BETWEEN => $this->getMessage(Between::NOT_BETWEEN)
+            ]
+        ];
+        $this->assertFalse($result);
+        $this->assertEquals($expected, $this->validator->getMessages());
+
+        $this->assertTrue($this->validator->validate(['number' => 2]));
+        $this->assertFalse($this->validator->validate(['number' => 10]));
+    }
+
+    /**
+     * @dataProvider getInvalidValues
+     * @param $value
+     */
+    public function testReturnsFalseForValuesNotBetweenMinAndMax($value)
+    {
+        $this->validator->required('number')->between(1, 10);
+        $result = $this->validator->validate(['number' => $value]);
+
+        $expected = [
+            'number' => [
+                Between::NOT_BETWEEN => $this->getMessage(Between::NOT_BETWEEN)
+            ]
+        ];
+        $this->assertFalse($result);
+        $this->assertEquals($expected, $this->validator->getMessages());
+    }
+
+    public function getInvalidValues()
+    {
+        return [
+            [-1, Between::NOT_BETWEEN],
+            [11, Between::NOT_BETWEEN]
+        ];
+    }
+
+    public function getMessage($reason)
+    {
+        $messages = [
+            Between::NOT_BETWEEN => 'Value of "number" must be between 1 and 10'
+        ];
+
+        return $messages[$reason];
+    }
+}

--- a/tests/Particle/Validator/Rule/CallbackTest.php
+++ b/tests/Particle/Validator/Rule/CallbackTest.php
@@ -1,0 +1,88 @@
+<?php
+use Particle\Validator\Exception\InvalidValueException;
+use Particle\Validator\Rule\Callback;
+use Particle\Validator\Validator;
+
+class CallbackTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Validator
+     */
+    protected $validator;
+
+    public function setUp()
+    {
+        $this->validator = new Validator();
+    }
+
+    public function testReturnsTrueWhenCallbackReturnsTrue()
+    {
+        $this->validator->required('first_name')->callback(function($value) {
+            return $value === 'berry';
+        });
+
+        $result = $this->validator->validate(['first_name' => 'berry']);
+        $this->assertTrue($result);
+    }
+
+    public function testReturnsFalseAndLogsErrorWhenCallbackReturnsFalse()
+    {
+        $this->validator->required('first_name')->callback(function($value) {
+            return $value !== 'berry';
+        });
+
+        $result = $this->validator->validate(['first_name' => 'berry']);
+        $this->assertFalse($result);
+
+        $expected = [
+            'first_name' => [
+                Callback::INVALID_VALUE => $this->getMessage(Callback::INVALID_VALUE)
+            ]
+        ];
+
+        $this->assertEquals($expected, $this->validator->getMessages());
+    }
+
+    public function testCanLogDifferentErrorMessageByThrowingException()
+    {
+        $this->validator->required('first_name')->callback(function($value) {
+            if ($value !== 'berry') {
+                throw new InvalidValueException(
+                    'This is my error',
+                    'Callback::CUSTOM'
+                );
+            }
+            return true;
+        });
+
+        $result = $this->validator->validate(['first_name' => 'bill']);
+        $this->assertFalse($result);
+
+        $expected = [
+            'first_name' => [
+                'Callback::CUSTOM' => 'This is my error'
+            ]
+        ];
+
+        $this->assertEquals($expected, $this->validator->getMessages());
+    }
+
+    public function testCanReadTheContextOfValidation()
+    {
+        $this->validator->required('first_name')->callback(function($value, $context) {
+            return $context['last_name'] === 'Langerak' && $value === 'Berry';
+        });
+
+        $result = $this->validator->validate(['first_name' => 'Berry', 'last_name' => 'Langerak']);
+        $this->assertTrue($result);
+    }
+
+    public function getMessage($reason)
+    {
+        $messages = [
+            Callback::INVALID_VALUE => 'The value of "first name" is invalid'
+        ];
+
+        return $messages[$reason];
+    }
+}

--- a/tests/Particle/Validator/Rule/DatetimeTest.php
+++ b/tests/Particle/Validator/Rule/DatetimeTest.php
@@ -1,0 +1,63 @@
+<?php
+use Particle\Validator\Validator;
+
+class DatetimeTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Validator
+     */
+    protected $validator;
+
+    public function setUp()
+    {
+        $this->validator = new Validator();
+    }
+
+    public function testRespectsFormatIfPassed()
+    {
+        $this->validator->required('time')->datetime('H:i');
+        $result = $this->validator->validate(['time' => '18:00']);
+
+        $this->assertTrue($result);
+
+        $result = $this->validator->validate(['time' => (new DateTime())->format('Y-m-d H:i:s')]);
+
+        $this->assertFalse($result);
+        $expected = [
+            'time' => [
+                \Particle\Validator\Rule\Datetime::INVALID_VALUE => 'The value of "time" is not a valid date'
+            ]
+        ];
+        $this->assertEquals($expected, $this->validator->getMessages());
+    }
+
+    public function testWillTakeManyFormatsIfNoFormatPassed()
+    {
+        $this->validator->required('time')->datetime();
+        $this->assertTrue($this->validator->validate(['time' => '18:00']));
+        $this->assertTrue($this->validator->validate(['time' => '2015-03-29 16:11:09']));
+        $this->assertTrue($this->validator->validate(['time' => '29-03-2015 16:11:09']));
+    }
+
+    public function testReturnsFalseOnUnparsableDate()
+    {
+        $this->validator->required('time')->datetime();
+        $result = $this->validator->validate(['time' => 'This is not a date. Not even close.']);
+
+        $this->assertFalse($result);
+        $expected = [
+            'time' => [
+                \Particle\Validator\Rule\Datetime::INVALID_VALUE => 'The value of "time" is not a valid date'
+            ]
+        ];
+        $this->assertEquals($expected, $this->validator->getMessages());
+    }
+
+    public function getMessage($reason)
+    {
+        $messages = [
+        ];
+
+        return $messages[$reason];
+    }
+}

--- a/tests/Particle/Validator/Rule/DigitsTest.php
+++ b/tests/Particle/Validator/Rule/DigitsTest.php
@@ -1,0 +1,56 @@
+<?php
+use Particle\Validator\Rule\Digits;
+use Particle\Validator\Validator;
+
+class DigitsTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Validator
+     */
+    protected $validator;
+
+    public function setUp()
+    {
+        $this->validator = new Validator();
+    }
+
+    public function testReturnsTrueOnOnlyDigitCharacters()
+    {
+        $this->validator->required('digits')->digits();
+        $this->assertTrue($this->validator->validate(['digits' => '123456789']));
+    }
+
+    /**
+     * @dataProvider getNotOnlyDigitValues
+     * @param string $value
+     */
+    public function testReturnsFalseOnNonDigitCharacters($value)
+    {
+        $this->validator->required('digits')->digits();
+        $this->assertFalse($this->validator->validate(['digits' => $value]));
+
+        $expected = [
+            'digits' => [
+                Digits::NOT_DIGITS => $this->getMessage(Digits::NOT_DIGITS)
+            ]
+        ];
+        $this->assertEquals($expected, $this->validator->getMessages());
+    }
+
+    public function getNotOnlyDigitValues()
+    {
+        return [
+            ['133.7'],
+            ['a1211']
+        ];
+    }
+
+    public function getMessage($reason)
+    {
+        $messages = [
+            Digits::NOT_DIGITS => 'The value of "digits" must consist only out of digits'
+        ];
+
+        return $messages[$reason];
+    }
+}

--- a/tests/Particle/Validator/Rule/EmailTest.php
+++ b/tests/Particle/Validator/Rule/EmailTest.php
@@ -1,0 +1,79 @@
+<?php
+use Particle\Validator\Rule\Digits;
+use Particle\Validator\Rule\Email;
+use Particle\Validator\Validator;
+
+class EmailTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Validator
+     */
+    protected $validator;
+
+    public function setUp()
+    {
+        $this->validator = new Validator();
+    }
+
+    /**
+     * @dataProvider getValidAddresses
+     * @param string $value
+     */
+    public function testReturnsTrueOnValidEmailaddresses($value)
+    {
+        $this->validator->required('email')->email();
+        $this->assertTrue($this->validator->validate(['email' => $value]));
+    }
+
+    /**
+     * @dataProvider getInvalidAddresses
+     * @param string $value
+     */
+    public function testReturnsFalseOnInvalidEmailaddresses($value)
+    {
+        $this->validator->required('email')->email();
+        $this->assertFalse($this->validator->validate(['email' => $value]));
+        $expected = [
+            'email' => [
+                Email::INVALID_FORMAT => 'The value of "email" must be a valid email address'
+            ]
+        ];
+        $this->assertEquals($expected, $this->validator->getMessages());
+    }
+
+    /**
+     * Returns a list of addresses considered valid.
+     *
+     * @return array
+     */
+    public function getValidAddresses()
+    {
+        return [
+            ['berry@github.com'],
+            ['berry+plus-sign@github.com.museum']
+        ];
+    }
+
+    /**
+     * Returns a list of addresses considered invalid.
+     *
+     * @return array
+     */
+    public function getInvalidAddresses()
+    {
+        return [
+            ['berry'],
+            ['not valid@"not valid"']
+        ];
+    }
+
+
+    public function getMessage($reason)
+    {
+        $messages = [
+            Digits::NOT_DIGITS => 'The value of "digits" must consist only out of digits'
+        ];
+
+        return $messages[$reason];
+    }
+}

--- a/tests/Particle/Validator/Rule/EqualTest.php
+++ b/tests/Particle/Validator/Rule/EqualTest.php
@@ -1,0 +1,36 @@
+<?php
+use Particle\Validator\Rule\Equal;
+use Particle\Validator\Validator;
+
+class EqualTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Validator
+     */
+    protected $validator;
+
+    public function setUp()
+    {
+        $this->validator = new Validator();
+    }
+
+    public function testReturnsTrueOnEqualValue()
+    {
+        $this->validator->required('first_name')->equals('berry');
+        $this->assertTrue($this->validator->validate(['first_name' => 'berry']));
+    }
+
+    public function testReturnsFalseOnNonEqualValue()
+    {
+        $this->validator->required('first_name')->equals(0);
+        $this->assertFalse($this->validator->validate(['first_name' => '0'])); // strict typing all the way!
+        $this->assertFalse($this->validator->validate(['first_name' => 'No cigar, and not even close.']));
+
+        $expected = [
+            'first_name' => [
+                Equal::NOT_EQUAL => 'The value of "first name" must be equal to "0"'
+            ]
+        ];
+        $this->assertEquals($expected, $this->validator->getMessages());
+    }
+}

--- a/tests/Particle/Validator/Rule/InArrayTest.php
+++ b/tests/Particle/Validator/Rule/InArrayTest.php
@@ -1,0 +1,62 @@
+<?php
+use Particle\Validator\Rule\InArray;
+use Particle\Validator\Validator;
+
+class InArrayTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Validator
+     */
+    protected $validator;
+
+    public function setUp()
+    {
+        $this->validator = new Validator();
+    }
+
+    public function testReturnsTrueIfValueIsInArrayWithStrictChecking()
+    {
+        $this->validator->required('group')->inArray(['foo', 'bar']);
+        $this->assertTrue($this->validator->validate(['group' => 'foo']));
+    }
+
+    public function testReturnsFalseIfValueIsNotInArrayWithStrictChecking()
+    {
+        $this->validator->required('group')->inArray([0]);
+        $this->assertFalse($this->validator->validate(['group' => '0']));
+
+        $expected = [
+            'group' => [
+                InArray::NOT_IN_ARRAY => 'The value of "group" is not in the defined set of values'
+            ]
+        ];
+
+        $this->assertEquals($expected, $this->validator->getMessages());
+    }
+
+    public function testCanUseTheValuesInErrorMessage()
+    {
+        $this->validator->required('group')->inArray(['users', 'admins']);
+
+        $this->validator->overwriteMessages([
+            'group' => [
+                InArray::NOT_IN_ARRAY => 'The value of "{{ name }}" must be one of {{ values }}'
+            ]
+        ]);
+        $this->assertFalse($this->validator->validate(['group' => 'none']));
+
+        $expected = [
+            'group' => [
+                InArray::NOT_IN_ARRAY => 'The value of "group" must be one of "users", "admins"'
+            ]
+        ];
+
+        $this->assertEquals($expected, $this->validator->getMessages());
+    }
+
+    public function testReturnsTrueIfValueIsSortOfInArrayWithoutStrictChecking()
+    {
+        $this->validator->required('group')->inArray([0], false);
+        $this->assertTrue($this->validator->validate(['group' => '0']));
+    }
+}

--- a/tests/Particle/Validator/Rule/LengthBetweenTest.php
+++ b/tests/Particle/Validator/Rule/LengthBetweenTest.php
@@ -1,0 +1,59 @@
+<?php
+use Particle\Validator\Rule\LengthBetween;
+use Particle\Validator\Validator;
+
+class LengthBetweenTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Validator
+     */
+    protected $validator;
+
+    public function setUp()
+    {
+        $this->validator = new Validator();
+    }
+
+    public function testReturnsTrueIfLengthIsExactlyMinOrMax()
+    {
+        $this->validator->required('first_name')->lengthBetween(2, 7);
+        $this->assertTrue($this->validator->validate(['first_name' => 'ad']));
+        $this->assertTrue($this->validator->validate(['first_name' => 'Richard']));
+        $this->assertEquals([], $this->validator->getMessages());
+    }
+
+    /**
+     * @dataProvider getValues
+     * @param $value
+     * @param $error
+     */
+    public function testReturnsFalseIfLengthIsExactlyMinOrMaxAndRuleIsExclusive($value, $error)
+    {
+        $this->validator->required('first_name')->lengthBetween(2, 7, false);
+        $this->assertFalse($this->validator->validate(['first_name' => $value]));
+        $expected = [
+            'first_name' => [
+                $error => $this->getMessage($error)
+            ]
+        ];
+        $this->assertEquals($expected, $this->validator->getMessages());
+    }
+
+    public function getMessage($reason)
+    {
+        $messages = [
+            LengthBetween::TOO_SHORT => 'The length of "first name" is too short, must be longer than 2 characters',
+            LengthBetween::TOO_LONG => 'The length of "first name" is too long, must be shorter than 7 characters',
+        ];
+
+        return $messages[$reason];
+    }
+
+    public function getValues()
+    {
+        return [
+            ['Ad', LengthBetween::TOO_SHORT],
+            ['Richard', LengthBetween::TOO_LONG]
+        ];
+    }
+}

--- a/tests/Particle/Validator/Rule/LengthTest.php
+++ b/tests/Particle/Validator/Rule/LengthTest.php
@@ -1,59 +1,68 @@
 <?php
-
-use Particle\Validator\MessageStack;
 use Particle\Validator\Rule\Length;
+use Particle\Validator\Validator;
 
 class LengthTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var Length
+     * @var Validator
      */
-    protected $rule;
-
-    /**
-     * @var MessageStack
-     */
-    protected $messageStack;
+    protected $validator;
 
     public function setUp()
     {
-        $this->messageStack = new MessageStack();
-
-        $this->rule = new Length(5);
-        $this->rule->setParameters('first_name', 'first name');
-        $this->rule->setMessageStack($this->messageStack);
+        $this->validator = new Validator();
     }
 
-    public function testTooShortWillLogTooShortError()
+    /**
+     * @dataProvider getInvalidValues
+     * @param $value
+     * @param $error
+     */
+    public function testInvalidValuesWillReturnFalseAndLogError($value, $error)
     {
-        $this->assertFalse($this->rule->isValid('first_name', ['first_name' => 'Rick']));
-        $expected = [
-            'first_name' => [
-                Length::TOO_SHORT => 'The value of "first name" is too short, should be 5 characters long'
-            ]
+        $this->validator->required('first_name')->length(5);
+        $result = $this->validator->validate(['first_name' => $value]);
+
+        $expected = ['first_name' => [$error => $this->getMessage($error)]];
+        $this->assertFalse($result);
+        $this->assertEquals($expected, $this->validator->getMessages());
+    }
+
+    /**
+     * @dataProvider getValidValues
+     * @param $value
+     */
+    public function testValidValuesWillReturnTrue($value)
+    {
+        $this->validator->required('first_name')->length(5);
+        $result = $this->validator->validate(['first_name' => $value]);
+
+        $this->assertTrue($result);
+    }
+
+    public function getInvalidValues()
+    {
+        return [
+            ['rick', Length::TOO_SHORT],
+            ['hendrik', Length::TOO_LONG]
         ];
-        $this->assertEquals($expected, $this->messageStack->getMessages());
     }
 
-    public function testTooLongWillLogTooLongError()
+    public function getValidValues()
     {
-        $this->assertFalse($this->rule->isValid('first_name', ['first_name' => 'Hendrick']));
-        $expected = [
-            'first_name' => [
-                Length::TOO_LONG => 'The value of "first name" is too long, should be 5 characters long'
-            ]
+        return [
+            ['berry'],
+            [12345] // integers are cast to strings
         ];
-        $this->assertEquals($expected, $this->messageStack->getMessages());
     }
 
-    public function testCorrectLengthWillLogNoErrors()
+    public function getMessage($reason)
     {
-        $this->assertTrue($this->rule->isValid('first_name', ['first_name' => 'Berry']));
-        $this->assertEquals([], $this->messageStack->getMessages());
-    }
-
-    public function testShouldNotBreakChainOnFailure()
-    {
-        $this->assertFalse($this->rule->shouldBreakChain());
+        $messages = [
+            Length::TOO_SHORT => 'The value of "first name" is too short, should be 5 characters long',
+            Length::TOO_LONG => 'The value of "first name" is too long, should be 5 characters long',
+        ];
+        return $messages[$reason];
     }
 }

--- a/tests/Particle/Validator/Rule/RegexTest.php
+++ b/tests/Particle/Validator/Rule/RegexTest.php
@@ -1,0 +1,36 @@
+<?php
+use Particle\Validator\Rule\Regex;
+use Particle\Validator\Validator;
+
+class RegexTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Validator
+     */
+    protected $validator;
+
+    public function setUp()
+    {
+        $this->validator = new Validator();
+    }
+
+    public function testReturnsTrueWhenMatchesRegex()
+    {
+        $this->validator->required('first_name')->regex('/^berry$/i');
+        $this->assertTrue($this->validator->validate(['first_name' => 'Berry']));
+        $this->assertEquals([], $this->validator->getMessages());
+    }
+
+    public function testReturnsFalseOnNoMatch()
+    {
+        $this->validator->required('first_name')->regex('~this wont match~');
+        $this->assertFalse($this->validator->validate(['first_name' => 'Berry']));
+        $expected = [
+            'first_name' => [
+                Regex::NO_MATCH => 'The value of "first name" is invalid'
+            ]
+        ];
+
+        $this->assertEquals($expected, $this->validator->getMessages());
+    }
+}

--- a/tests/Particle/Validator/Rule/UrlTest.php
+++ b/tests/Particle/Validator/Rule/UrlTest.php
@@ -1,0 +1,60 @@
+<?php
+use Particle\Validator\Rule\Url;
+use Particle\Validator\Validator;
+
+class UrlTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Validator
+     */
+    protected $validator;
+
+    public function setUp()
+    {
+        $this->validator = new Validator();
+    }
+
+    /**
+     * @dataProvider getValidUrls
+     * @param string $value
+     */
+    public function testReturnsTrueOnValidUrls($value)
+    {
+        $this->validator->required('url')->url();
+        $this->assertTrue($this->validator->validate(['url' => $value]));
+        $this->assertEquals([], $this->validator->getMessages());
+    }
+
+    /**
+     * @dataProvider getInvalidUrls
+     * @param string $value
+     * @param string $error
+     */
+    public function testReturnsFalseOnInvalidUrls($value, $error)
+    {
+        $this->validator->required('url')->url();
+        $this->assertFalse($this->validator->validate(['url' => $value]));
+        $expected = [
+            'url' => [
+                Url::INVALID_URL => 'The value of "url" must be a valid URL.'
+            ]
+        ];
+        $this->assertEquals($expected, $this->validator->getMessages());
+    }
+
+    public function getValidUrls()
+    {
+        return [
+            ['http://github.com'],
+            ['git://berry:berry@github.com/berry-langerak/Validator?view=source&value=yes']
+        ];
+    }
+
+    public function getInvalidUrls()
+    {
+        return [
+            ['malformed:/github.com', Url::INVALID_URL],
+            ['http:///github.com', Url::INVALID_URL]
+        ];
+    }
+}

--- a/tests/Particle/Validator/ValidatorTest.php
+++ b/tests/Particle/Validator/ValidatorTest.php
@@ -198,7 +198,7 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
     public function testDefaultMessageOverwrites()
     {
         $this->validator->overwriteDefaultMessages([
-            Rule\Length::TOO_SHORT => 'De waarde is te kort. Dit moet minimaal {{ length }} karakters bevatten'
+            Rule\Length::TOO_SHORT => 'this is my overwritten message. {{ length }} is the length.'
         ]);
 
         $this->validator->required('first_name', 'Voornaam')->length(5);
@@ -206,7 +206,7 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
 
         $expected = [
             'first_name' => [
-                Rule\Length::TOO_SHORT => 'De waarde is te kort. Dit moet minimaal 5 karakters bevatten'
+                Rule\Length::TOO_SHORT => 'this is my overwritten message. 5 is the length.'
             ]
         ];
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,4 +3,3 @@ date_default_timezone_set('UTC');
 
 // require the composer autoloader
 require_once __DIR__ . '/../vendor/autoload.php';
-


### PR DESCRIPTION
To make Particle\Validator actually usable in existing software, default rules should be added. This PR will add a whole lot of validation rules to the library. The current status is as follows:

- [x] alnum
- [x] alpha
- [x] between
- [x] callback
- [x] dateTime
- [x] digits
- [x] email
- [x] equal
- [x] inArray
- [x] length
- [x] lengthBetween
- [x] regex
- [x] url

Because I'm not sure whether they are going to be very useful, I'm postponing the following rules:

 - [ ] float
 - [ ] notEqual
 - [ ] notInArray
