### PR TITLE
Get validated values

### DIFF
--- a/src/Particle/Validator/Chain.php
+++ b/src/Particle/Validator/Chain.php
@@ -7,6 +7,7 @@
  * @license   https://github.com/particle-php/validator/blob/master/LICENSE New BSD License
  */
 namespace Particle\Validator;
+use Particle\Validator\Value\Container;
 
 /**
  * Represents a collection of Rules which may break the chain of validation (but usually don't).
@@ -236,17 +237,20 @@ class Chain
      * Validates the values in the $values array and appends messages to $messageStack. Returns the result as a bool.
      *
      * @param MessageStack $messageStack
-     * @param array $values
+     * @param Container $input
+     * @param Container $output
      * @return bool
      */
-    public function validate(MessageStack $messageStack, array $values)
+    public function validate(MessageStack $messageStack, Container $input, Container $output)
     {
         $valid = true;
+        $output->set($this->key, $input->get($this->key));
+
         foreach ($this->rules as $rule) {
             $rule->setMessageStack($messageStack);
             $rule->setParameters($this->key, $this->name);
 
-            $valid = $rule->isValid($this->key, $values) && $valid;
+            $valid = $rule->isValid($this->key, $input->getArrayCopy()) && $valid;
 
             if ($rule->shouldBreakChain()) {
                 return $valid;

--- a/src/Particle/Validator/Chain.php
+++ b/src/Particle/Validator/Chain.php
@@ -250,7 +250,7 @@ class Chain
             $rule->setMessageStack($messageStack);
             $rule->setParameters($this->key, $this->name);
 
-            $valid = $rule->isValid($this->key, $input->getArrayCopy()) && $valid;
+            $valid = $rule->isValid($this->key, $input) && $valid;
 
             if ($rule->shouldBreakChain()) {
                 return $valid;

--- a/src/Particle/Validator/Chain.php
+++ b/src/Particle/Validator/Chain.php
@@ -7,6 +7,7 @@
  * @license   https://github.com/particle-php/validator/blob/master/LICENSE New BSD License
  */
 namespace Particle\Validator;
+
 use Particle\Validator\Value\Container;
 
 /**

--- a/src/Particle/Validator/Rule.php
+++ b/src/Particle/Validator/Rule.php
@@ -7,6 +7,7 @@
  * @license   https://github.com/particle-php/validator/blob/master/LICENSE New BSD License
  */
 namespace Particle\Validator;
+use Particle\Validator\Value\Container;
 
 /**
  * The Rule class is the abstract parent of all rules of Particle and defines their common behaviour.
@@ -98,13 +99,12 @@ abstract class Rule
      * Determines whether or not the value of $key is valid in the array $values and returns the result as a bool.
      *
      * @param string $key
-     * @param array $values
+     * @param Container $input
      * @return bool
      */
-    public function isValid($key, array $values)
+    public function isValid($key, Container $input)
     {
-        $value = array_key_exists($key, $values) ? $values[$key] : null;
-        return $this->validate($value, $values);
+        return $this->validate($input->get($key), $input->getArrayCopy());
     }
 
     /**

--- a/src/Particle/Validator/Rule.php
+++ b/src/Particle/Validator/Rule.php
@@ -7,6 +7,7 @@
  * @license   https://github.com/particle-php/validator/blob/master/LICENSE New BSD License
  */
 namespace Particle\Validator;
+
 use Particle\Validator\Value\Container;
 
 /**

--- a/src/Particle/Validator/Rule/Callback.php
+++ b/src/Particle/Validator/Rule/Callback.php
@@ -10,6 +10,7 @@ namespace Particle\Validator\Rule;
 
 use Particle\Validator\Exception\InvalidValueException;
 use Particle\Validator\Rule;
+use Particle\Validator\Value\Container;
 
 /**
  * This rule is for validating a value with a custom callback.
@@ -36,6 +37,11 @@ class Callback extends Rule
      * @var callable
      */
     protected $callback;
+
+    /**
+     * @var Container
+     */
+    protected $input;
 
     /**
      * Construct the Callback validator.
@@ -74,12 +80,13 @@ class Callback extends Rule
      * Validates the value according to this rule, and returns the result as a bool.
      *
      * @param string $key
-     * @param array $values
+     * @param Container $input
      * @return bool
      */
-    public function isValid($key, array $values)
+    public function isValid($key, Container $input)
     {
-        $this->values = $values;
-        return parent::isValid($key, $values);
+        $this->values = $input->getArrayCopy();
+
+        return parent::isValid($key, $input);
     }
 }

--- a/src/Particle/Validator/Validator.php
+++ b/src/Particle/Validator/Validator.php
@@ -8,6 +8,8 @@
  */
 namespace Particle\Validator;
 
+use Particle\Validator\Value\Container;
+
 class Validator
 {
     /**
@@ -42,6 +44,13 @@ class Validator
      * @var array
      */
     protected $defaultMessages = [];
+
+    /**
+     * Contains a Value\Container to keep track of all values we *have* validated.
+     *
+     * @var Container
+     */
+    protected $output;
 
     /**
      * Construct the validator.
@@ -88,12 +97,25 @@ class Validator
     {
         $valid = true;
         $messageStack = $this->buildMessageStack($context);
+        $this->output = new Container();
+        $input = new Container($values);
 
         foreach ($this->chains[$context] as $chain) {
             /** @var Chain $chain */
-            $valid = $chain->validate($messageStack, $values) && $valid;
+            $valid = $chain->validate($messageStack, $input, $this->output) && $valid;
         }
         return $valid;
+    }
+
+    /**
+     * @return array
+     */
+    public function getValues()
+    {
+        if (!$this->output instanceof Container) {
+            return [];
+        }
+        return $this->output->getArrayCopy();
     }
 
     /**

--- a/src/Particle/Validator/Value/Container.php
+++ b/src/Particle/Validator/Value/Container.php
@@ -1,14 +1,30 @@
 <?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/validator/blob/master/LICENSE New BSD License
+ */
 namespace Particle\Validator\Value;
 
+/**
+ * This class is used to wrap both input as output arrays.
+ *
+ * @package Particle\Validator
+ */
 class Container
 {
     /**
+     * Contains the values (either input or output).
+     *
      * @var array
      */
     protected $values = [];
 
     /**
+     * Construct the Value\Container.
+     *
      * @param array $values
      */
     public function __construct(array $values = [])
@@ -16,22 +32,46 @@ class Container
         $this->values = $values;
     }
 
+    /**
+     * Determines whether or not the container has a value for key $key.
+     *
+     * @param string $key
+     * @return bool
+     */
     public function has($key)
     {
         return isset($this->values[$key]);
     }
 
+    /**
+     * Returns the value for the key $key, or null if the value doesn't exist.
+     *
+     * @param string $key
+     * @return mixed
+     */
     public function get($key)
     {
         return $this->has($key) ? $this->values[$key] : null;
     }
 
+    /**
+     * Set the value of $key to $value.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @return $this
+     */
     public function set($key, $value)
     {
         $this->values[$key] = $value;
         return $this;
     }
 
+    /**
+     * Returns a plain array representation of the Value\Container object.
+     *
+     * @return array
+     */
     public function getArrayCopy()
     {
         return $this->values;

--- a/src/Particle/Validator/Value/Container.php
+++ b/src/Particle/Validator/Value/Container.php
@@ -1,0 +1,39 @@
+<?php
+namespace Particle\Validator\Value;
+
+class Container
+{
+    /**
+     * @var array
+     */
+    protected $values = [];
+
+    /**
+     * @param array $values
+     */
+    public function __construct(array $values = [])
+    {
+        $this->values = $values;
+    }
+
+    public function has($key)
+    {
+        return isset($this->values[$key]);
+    }
+
+    public function get($key)
+    {
+        return $this->has($key) ? $this->values[$key] : null;
+    }
+
+    public function set($key, $value)
+    {
+        $this->values[$key] = $value;
+        return $this;
+    }
+
+    public function getArrayCopy()
+    {
+        return $this->values;
+    }
+}

--- a/tests/Particle/Validator/RuleTest.php
+++ b/tests/Particle/Validator/RuleTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Particle\Validator\Rule;
+use Particle\Validator\Value\Container;
 
 class RuleTest extends PHPUnit_Framework_TestCase
 {
@@ -23,6 +24,6 @@ class RuleTest extends PHPUnit_Framework_TestCase
 
         $length->setMessageStack($ms);
 
-        $this->assertFalse($length->isValid('first_name', ['first_name' => '']));
+        $this->assertFalse($length->isValid('first_name', new Container(['first_name' => ''])));
     }
 }

--- a/tests/Particle/Validator/ValidatorTest.php
+++ b/tests/Particle/Validator/ValidatorTest.php
@@ -4,6 +4,7 @@ use Particle\Validator\Rule;
 use Particle\Validator\Validator;
 
 use Particle\Validator\Rule\Required;
+use Particle\Validator\Value\Container;
 
 class ValidatorTest extends PHPUnit_Framework_TestCase
 {
@@ -192,7 +193,7 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
 
         $stack = new MessageStack();
         $this->assertEquals($first, $second);
-        $this->assertFalse($second->validate($stack, [])); // because it's required.
+        $this->assertFalse($second->validate($stack, new Container([]), new Container([]))); // because it's required.
     }
 
     public function testDefaultMessageOverwrites()
@@ -235,5 +236,24 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
         ];
 
         $this->assertEquals($expected, $this->validator->getMessages());
+    }
+
+    public function testReturnsValidatedValues()
+    {
+        $this->validator->required('first_name')->lengthBetween(2, 20);
+        $this->validator->required('last_name')->lengthBetween(2, 60);
+
+        $this->validator->validate([
+            'first_name' => 'Berry',
+            'last_name' => 'Langerak',
+            'is_admin' => true
+        ]);
+
+        $expected = [
+            'first_name' => 'Berry',
+            'last_name' => 'Langerak',
+        ];
+
+        $this->assertEquals($expected, $this->validator->getValues());
     }
 }


### PR DESCRIPTION
It might be nice to be able to get only values where validation rules were built for. This PR creates that functionality. So;

```php
$v = new Validator;
$v->required('first_name')->lengthBetween(2, 10);
$v->validate([
    'first_name' => 'Berry',
    'is_admin_user' => true // this is not validated, so should disappear.
]);

print_r($v->getValues(), true); // ['first_name' => 'Berry']
```