### PR TITLE
Maximum length can now be null for cases where you want no maximum length

### DIFF
--- a/src/Particle/Validator/Chain.php
+++ b/src/Particle/Validator/Chain.php
@@ -173,10 +173,12 @@ class Chain
     }
 
     /**
-     * Validates that the length of the value is between $min and $max. Inclusive is the default.
+     * Validates that the length of the value is between $min and $max.
+     *
+     * If $max is null, it has no upper limit. The default is inclusive.
      *
      * @param int $min
-     * @param int $max
+     * @param int|null $max
      * @param bool $inclusive
      * @return Chain
      */

--- a/src/Particle/Validator/Rule/LengthBetween.php
+++ b/src/Particle/Validator/Rule/LengthBetween.php
@@ -60,7 +60,7 @@ class LengthBetween extends Rule
 
     /**
      * @param int $min
-     * @param int $max
+     * @param int|null $max
      * @param bool $inclusive
      */
     public function __construct($min, $max, $inclusive = true)
@@ -80,8 +80,10 @@ class LengthBetween extends Rule
     {
         $length = strlen($value);
 
-        if (($this->inclusive && $length > $this->max) || (!$this->inclusive && $length >= $this->max)) {
-            return $this->error(self::TOO_LONG);
+        if ($this->max !== null) {
+            if (($this->inclusive && $length > $this->max) || (!$this->inclusive && $length >= $this->max)) {
+                return $this->error(self::TOO_LONG);
+            }
         }
 
         if (($this->inclusive && $length < $this->min) || (!$this->inclusive && $length <= $this->min)) {

--- a/tests/Particle/Validator/Rule/LengthBetweenTest.php
+++ b/tests/Particle/Validator/Rule/LengthBetweenTest.php
@@ -22,6 +22,13 @@ class LengthBetweenTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([], $this->validator->getMessages());
     }
 
+    public function testReturnsTrueIfMaxIsNull()
+    {
+        $this->validator->required('password')->lengthBetween(2, null);
+        $this->assertTrue($this->validator->validate(['password' => str_repeat('foo', 100)]));
+        $this->assertEquals([], $this->validator->getMessages());
+    }
+
     /**
      * @dataProvider getValues
      * @param $value


### PR DESCRIPTION
In some cases (a password field comes to mind), you don't want to have a maximum length, but you *do* want a minimum length. This PR makes sure you can set the maximum to null, disabling the checking.