### PR TITLE
Context will now inherit messages from default context.

### DIFF
--- a/src/Particle/Validator/Validator.php
+++ b/src/Particle/Validator/Validator.php
@@ -193,8 +193,10 @@ class Validator
         $this->messageStack = new MessageStack();
         $this->messageStack->overwriteDefaultMessages($this->defaultMessages);
 
-        if (isset($this->messageOverwrites[$context])) {
-            $this->messageStack->overwriteMessages($this->messageOverwrites[$context]);
+        foreach ([self::DEFAULT_CONTEXT, $context] as $currentContext) {
+            if (isset($this->messageOverwrites[$currentContext])) {
+                $this->messageStack->overwriteMessages($this->messageOverwrites[$currentContext]);
+            }
         }
 
         return $this->messageStack;

--- a/tests/Particle/Validator/ContextTest.php
+++ b/tests/Particle/Validator/ContextTest.php
@@ -56,4 +56,27 @@ class ContextTest extends PHPUnit_Framework_TestCase
         ];
         $this->assertEquals($expected, $this->validator->getMessages());
     }
+
+    public function testMessagesWillBeInheritedFromDefaultContext()
+    {
+        $this->validator->context('insert', function (Validator $context) {
+            $context->required('first_name')->length(5);
+        });
+
+        $this->validator->overwriteMessages([
+            'first_name' => [
+                Rule\Length::TOO_SHORT => 'This is outside of the context',
+            ]
+        ]);
+
+        $this->validator->validate(['first_name' => 'Rick'], 'insert');
+
+        $expected = [
+            'first_name' => [
+                Rule\Length::TOO_SHORT => 'This is outside of the context'
+            ]
+        ];
+
+        $this->assertEquals($expected, $this->validator->getMessages());
+    }
 }


### PR DESCRIPTION
The overwritten messages in the "default" context were not used inside a different context. This PR fixes that, so you can do this:

```php
$v = new Validator;
$v->overwriteMessages([
   'first_name' => [
      Length::TOO_SHORT => 'The value is too short.'
   ]
]);
$v->context('insert', function(Validator $c)) {
   $c->required('first_name')->length(5);
});
$v->validate(['first_name' => 'foo']);
$v->getMessages()['first_name'][Length::TOO_SHORT]; // "The value is too short"
```