### PR TITLE
You can now copy chains from one context into the current context

### DIFF
--- a/src/Particle/Validator/Chain.php
+++ b/src/Particle/Validator/Chain.php
@@ -62,6 +62,18 @@ class Chain
     }
 
     /**
+     * Overwrite the default __clone behaviour to make sure the rules are cloned too.
+     */
+    public function __clone()
+    {
+        $rules = [];
+        foreach ($this->rules as $rule) {
+            $rules[] = clone $rule;
+        }
+        $this->rules = $rules;
+    }
+
+    /**
      * Validate the value to consist only out of alphanumeric characters.
      *
      * @param bool $allowWhitespace

--- a/src/Particle/Validator/Validator.php
+++ b/src/Particle/Validator/Validator.php
@@ -129,6 +129,35 @@ class Validator
     }
 
     /**
+     * Copy the rules and messages of the context $otherContext to the current context.
+     *
+     * @param string $otherContext
+     * @param callable|null $callback
+     * @return $this
+     */
+    public function copyContext($otherContext, callable $callback = null)
+    {
+        if (isset($this->messageOverwrites[$otherContext])) {
+            $this->messageOverwrites[$this->context] = $this->messageOverwrites[$otherContext];
+        }
+
+        if (isset($this->chains[$otherContext])) {
+            $clonedChains = [];
+            foreach ($this->chains[$otherContext] as $key => $chain) {
+                $clonedChains[$key] = clone $chain;
+            }
+
+            if ($callback !== null) {
+                $callback($clonedChains);
+            }
+
+            $this->chains[$this->context] = $clonedChains;
+        }
+
+        return $this;
+    }
+
+    /**
      * Create a new validation context with the closure $closure.
      *
      * @param string $name

--- a/tests/Particle/Validator/ContextTest.php
+++ b/tests/Particle/Validator/ContextTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Particle\Validator\Context;
+use Particle\Validator\Chain;
 use Particle\Validator\Rule;
 use Particle\Validator\Validator;
 
@@ -78,5 +78,71 @@ class ContextTest extends PHPUnit_Framework_TestCase
         ];
 
         $this->assertEquals($expected, $this->validator->getMessages());
+    }
+
+    public function testContextCanCopyRulesFromOtherContext()
+    {
+        $this->validator->context('insert', function(Validator $context) {
+            $context->overwriteMessages([
+                'first_name' => [
+                    Rule\Length::TOO_SHORT => 'From inside the "insert" context.'
+                ]
+            ]);
+
+            $context->required('first_name')->length(5);
+        });
+
+        $this->validator->context('update', function(Validator $context) {
+            $context->copyContext('insert');
+        });
+
+        $this->assertFalse($this->validator->validate(['first_name' => 'Rick'], 'update'));
+
+        $expected = [
+            'first_name' => [
+                Rule\Length::TOO_SHORT => 'From inside the "insert" context.'
+            ]
+        ];
+        $this->assertEquals($expected, $this->validator->getMessages());
+    }
+
+    public function testContextCopyCanAlterChains()
+    {
+        $this->validator->context('insert', function(Validator $context) {
+            $context->required('first_name')->length(5);
+        });
+
+        $this->validator->context('update', function(Validator $context) {
+            $context->copyContext('insert', function(array $chains) {
+                /** @var Chain $chain */
+                foreach ($chains as $chain) {
+                    $chain->required(function() {
+                        return false; // all fields optional.
+                    });
+                }
+            });
+        });
+
+        $this->assertTrue($this->validator->validate([], 'update'));
+    }
+
+    public function testContextCopyClonesButDoesNotOverwrite()
+    {
+        $this->validator->context('insert', function(Validator $context) {
+            $context->required('first_name')->length(5);
+        });
+
+        $this->validator->context('update', function(Validator $context) {
+            $context->copyContext('insert', function(array $chains) {
+                /** @var Chain $chain */
+                foreach ($chains as $chain) {
+                    $chain->required(function() {
+                        return false; // all fields optional.
+                    });
+                }
+            });
+        });
+
+        $this->assertFalse($this->validator->validate([], 'insert'));
     }
 }


### PR DESCRIPTION
This PR introduces copying of the rules and messages of a context, which allows the following:

```php
$v = new Validator;

$v->context('insert', function(Validator $c) {
   $c->required('first_name')->length(5);
});

$v->context('update', function(Validator $c) {
   $c->copyContext('insert', function(array $chains) {
      foreach ($chains as $chain) {
         $chain->setRequired(function() { // in update context, the values are all optional. 
            return false; 
         });
      }
   });
});

$v->validate([], 'update'); // (bool) true because "first_name" is now optional.
```

Of course, the callback is meant just for looping over the existing chains, if you want to simply extend the existing rule chains, this would also be possible:

```php
$v = new Validator;

$v->context('insert', function(Validator $c) {
   $c->required('first_name')->length(5);
});

$v->context('update', function(Validator $c) {
   $c->copyContext('insert');
   $c->required('first_name')->regex('/^[a-z]+$/i');
});

$v->validate(['first_name' => '12345'], 'update'); // (bool) false, because doesn't match '/^[a-z]+$/i'. 
```