### PR TITLE
Add a validation rule for an integer value

### DIFF
--- a/src/Particle/Validator/Chain.php
+++ b/src/Particle/Validator/Chain.php
@@ -141,6 +141,17 @@ class Chain
     }
 
     /**
+     * Validates the value represents a valid integer
+     *
+     * @return $this
+     * @see \Particle\Validator\Rule\Integer
+     */
+    public function integer()
+    {
+        return $this->addRule(new Rule\Integer());
+    }
+
+    /**
      * Validates that the value is a valid email address (format only).
      * @return $this
      */

--- a/src/Particle/Validator/Rule/Integer.php
+++ b/src/Particle/Validator/Rule/Integer.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/validator/blob/master/LICENSE New BSD License
+ */
+namespace Particle\Validator\Rule;
+
+use Particle\Validator\Rule;
+
+/**
+ * This rule is for validating if a value represents an integer.
+ *
+ * @package Particle\Validator\Rule
+ */
+class Integer extends Rule
+{
+    /**
+     * A constant that will be used when the value does not represent an integer value.
+     */
+    const NOT_AN_INTEGER = 'Integer::NOT_AN_INTEGER';
+
+    /**
+     * The message templates which can be returned by this validator.
+     *
+     * @var array
+     */
+    protected $messageTemplates = [
+        self::NOT_AN_INTEGER => 'The value of "{{ name }}" must represent an integer',
+    ];
+
+    /**
+     * Validates if $value represents an integer.
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function validate($value)
+    {
+        if (false !== filter_var($value, FILTER_VALIDATE_INT)) {
+            return true;
+        }
+        return $this->error(self::NOT_AN_INTEGER);
+    }
+}

--- a/tests/Particle/Validator/Rule/DigitsTest.php
+++ b/tests/Particle/Validator/Rule/DigitsTest.php
@@ -41,7 +41,8 @@ class DigitsTest extends PHPUnit_Framework_TestCase
     {
         return [
             ['133.7'],
-            ['a1211']
+            ['a1211'],
+            ['-12'],
         ];
     }
 

--- a/tests/Particle/Validator/Rule/IntegerTest.php
+++ b/tests/Particle/Validator/Rule/IntegerTest.php
@@ -1,0 +1,73 @@
+<?php
+use Particle\Validator\Rule\Integer;
+use Particle\Validator\Validator;
+
+class IntegerTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Validator
+     */
+    protected $validator;
+
+    public function setUp()
+    {
+        $this->validator = new Validator();
+    }
+
+    /**
+     * @dataProvider getValidIntegerValues
+     * @param mixed $value
+     */
+    public function testReturnsTrueOnValidInteger($value)
+    {
+        $this->validator->required('integer')->integer();
+        $this->assertTrue($this->validator->validate(['integer' => $value]));
+    }
+
+    /**
+     * @dataProvider getInvalidIntegerValues
+     * @param string $value
+     */
+    public function testReturnsFalseOnInvalidIntegers($value)
+    {
+        $this->validator->required('integer')->integer();
+        $this->assertFalse($this->validator->validate(['integer' => $value]));
+
+        $expected = [
+            'integer' => [
+                Integer::NOT_AN_INTEGER => $this->getMessage(Integer::NOT_AN_INTEGER)
+            ]
+        ];
+        $this->assertEquals($expected, $this->validator->getMessages());
+    }
+
+    public function getValidIntegerValues()
+    {
+        return [
+            ['1337'],
+            ['1211'],
+            ['0'],
+            [1231],
+            [-12],
+            ['-12'],
+            [0xFF],
+        ];
+    }
+
+    public function getInvalidIntegerValues()
+    {
+        return [
+            ['133.7'],
+            ['a1211'],
+        ];
+    }
+
+    public function getMessage($reason)
+    {
+        $messages = [
+            Integer::NOT_AN_INTEGER => 'The value of "integer" must represent an integer'
+        ];
+
+        return $messages[$reason];
+    }
+}


### PR DESCRIPTION
I was validating a negative number value with the digits validator the other day, but obviously the `-` is not considered a digit.