### PR TITLE
Make the tests PSR-2 valid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
 
 script:
   - php vendor/bin/phpunit --coverage-clover=coverage.clover
-  - php vendor/bin/phpcs -n --standard=PSR2 ./src
+  - php vendor/bin/phpcs -n --standard=PSR2 --ignore=vendor .
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/tests/Particle/Validator/ContextTest.php
+++ b/tests/Particle/Validator/ContextTest.php
@@ -1,10 +1,11 @@
 <?php
+namespace Particle\Tests;
 
 use Particle\Validator\Chain;
 use Particle\Validator\Rule;
 use Particle\Validator\Validator;
 
-class ContextTest extends PHPUnit_Framework_TestCase
+class ContextTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Validator
@@ -18,7 +19,7 @@ class ContextTest extends PHPUnit_Framework_TestCase
 
     public function testCanBeValidatedIndependently()
     {
-        $this->validator->context('insert', function(Validator $context) {
+        $this->validator->context('insert', function (Validator $context) {
             $context->required('first_name')->length(5);
         });
 
@@ -82,7 +83,7 @@ class ContextTest extends PHPUnit_Framework_TestCase
 
     public function testContextCanCopyRulesFromOtherContext()
     {
-        $this->validator->context('insert', function(Validator $context) {
+        $this->validator->context('insert', function (Validator $context) {
             $context->overwriteMessages([
                 'first_name' => [
                     Rule\Length::TOO_SHORT => 'From inside the "insert" context.'
@@ -92,7 +93,7 @@ class ContextTest extends PHPUnit_Framework_TestCase
             $context->required('first_name')->length(5);
         });
 
-        $this->validator->context('update', function(Validator $context) {
+        $this->validator->context('update', function (Validator $context) {
             $context->copyContext('insert');
         });
 
@@ -108,15 +109,15 @@ class ContextTest extends PHPUnit_Framework_TestCase
 
     public function testContextCopyCanAlterChains()
     {
-        $this->validator->context('insert', function(Validator $context) {
+        $this->validator->context('insert', function (Validator $context) {
             $context->required('first_name')->length(5);
         });
 
-        $this->validator->context('update', function(Validator $context) {
-            $context->copyContext('insert', function(array $chains) {
+        $this->validator->context('update', function (Validator $context) {
+            $context->copyContext('insert', function (array $chains) {
                 /** @var Chain $chain */
                 foreach ($chains as $chain) {
-                    $chain->required(function() {
+                    $chain->required(function () {
                         return false; // all fields optional.
                     });
                 }
@@ -128,15 +129,15 @@ class ContextTest extends PHPUnit_Framework_TestCase
 
     public function testContextCopyClonesButDoesNotOverwrite()
     {
-        $this->validator->context('insert', function(Validator $context) {
+        $this->validator->context('insert', function (Validator $context) {
             $context->required('first_name')->length(5);
         });
 
-        $this->validator->context('update', function(Validator $context) {
-            $context->copyContext('insert', function(array $chains) {
+        $this->validator->context('update', function (Validator $context) {
+            $context->copyContext('insert', function (array $chains) {
                 /** @var Chain $chain */
                 foreach ($chains as $chain) {
-                    $chain->required(function() {
+                    $chain->required(function () {
                         return false; // all fields optional.
                     });
                 }

--- a/tests/Particle/Validator/MessageStackTest.php
+++ b/tests/Particle/Validator/MessageStackTest.php
@@ -1,8 +1,9 @@
 <?php
+namespace Particle\Tests;
 
 use Particle\Validator\MessageStack;
 
-class MessageChainTest extends PHPUnit_Framework_TestCase
+class MessageChainTest extends \PHPUnit_Framework_TestCase
 {
     public function testCanFormatMessagesByReplacingPlaceholders()
     {

--- a/tests/Particle/Validator/Rule/AlnumTest.php
+++ b/tests/Particle/Validator/Rule/AlnumTest.php
@@ -1,8 +1,10 @@
 <?php
+namespace Particle\Tests\Rule;
+
 use Particle\Validator\Rule\Alnum;
 use Particle\Validator\Validator;
 
-class AlnumTest extends PHPUnit_Framework_TestCase
+class AlnumTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Validator

--- a/tests/Particle/Validator/Rule/AlphaTest.php
+++ b/tests/Particle/Validator/Rule/AlphaTest.php
@@ -1,8 +1,10 @@
 <?php
+namespace Particle\Tests\Rule;
+
 use Particle\Validator\Rule\Alpha;
 use Particle\Validator\Validator;
 
-class AlphaTest extends PHPUnit_Framework_TestCase
+class AlphaTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Validator

--- a/tests/Particle/Validator/Rule/BetweenTest.php
+++ b/tests/Particle/Validator/Rule/BetweenTest.php
@@ -1,8 +1,10 @@
 <?php
+namespace Particle\Tests\Rule;
+
 use Particle\Validator\Rule\Between;
 use Particle\Validator\Validator;
 
-class BetweenTest extends PHPUnit_Framework_TestCase
+class BetweenTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Validator

--- a/tests/Particle/Validator/Rule/CallbackTest.php
+++ b/tests/Particle/Validator/Rule/CallbackTest.php
@@ -1,9 +1,11 @@
 <?php
+namespace Particle\Tests\Rule;
+
 use Particle\Validator\Exception\InvalidValueException;
 use Particle\Validator\Rule\Callback;
 use Particle\Validator\Validator;
 
-class CallbackTest extends PHPUnit_Framework_TestCase
+class CallbackTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Validator
@@ -17,7 +19,7 @@ class CallbackTest extends PHPUnit_Framework_TestCase
 
     public function testReturnsTrueWhenCallbackReturnsTrue()
     {
-        $this->validator->required('first_name')->callback(function($value) {
+        $this->validator->required('first_name')->callback(function ($value) {
             return $value === 'berry';
         });
 
@@ -27,7 +29,7 @@ class CallbackTest extends PHPUnit_Framework_TestCase
 
     public function testReturnsFalseAndLogsErrorWhenCallbackReturnsFalse()
     {
-        $this->validator->required('first_name')->callback(function($value) {
+        $this->validator->required('first_name')->callback(function ($value) {
             return $value !== 'berry';
         });
 
@@ -45,7 +47,7 @@ class CallbackTest extends PHPUnit_Framework_TestCase
 
     public function testCanLogDifferentErrorMessageByThrowingException()
     {
-        $this->validator->required('first_name')->callback(function($value) {
+        $this->validator->required('first_name')->callback(function ($value) {
             if ($value !== 'berry') {
                 throw new InvalidValueException(
                     'This is my error',
@@ -69,7 +71,7 @@ class CallbackTest extends PHPUnit_Framework_TestCase
 
     public function testCanReadTheContextOfValidation()
     {
-        $this->validator->required('first_name')->callback(function($value, $context) {
+        $this->validator->required('first_name')->callback(function ($value, $context) {
             return $context['last_name'] === 'Langerak' && $value === 'Berry';
         });
 

--- a/tests/Particle/Validator/Rule/DatetimeTest.php
+++ b/tests/Particle/Validator/Rule/DatetimeTest.php
@@ -1,7 +1,10 @@
 <?php
-use Particle\Validator\Validator;
+namespace Particle\Tests\Rule;
 
-class DatetimeTest extends PHPUnit_Framework_TestCase
+use Particle\Validator\Validator;
+use \DateTime;
+
+class DatetimeTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Validator

--- a/tests/Particle/Validator/Rule/DigitsTest.php
+++ b/tests/Particle/Validator/Rule/DigitsTest.php
@@ -1,8 +1,10 @@
 <?php
+namespace Particle\Tests\Rule;
+
 use Particle\Validator\Rule\Digits;
 use Particle\Validator\Validator;
 
-class DigitsTest extends PHPUnit_Framework_TestCase
+class DigitsTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Validator

--- a/tests/Particle/Validator/Rule/EmailTest.php
+++ b/tests/Particle/Validator/Rule/EmailTest.php
@@ -1,9 +1,11 @@
 <?php
+namespace Particle\Tests\Rule;
+
 use Particle\Validator\Rule\Digits;
 use Particle\Validator\Rule\Email;
 use Particle\Validator\Validator;
 
-class EmailTest extends PHPUnit_Framework_TestCase
+class EmailTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Validator

--- a/tests/Particle/Validator/Rule/EqualTest.php
+++ b/tests/Particle/Validator/Rule/EqualTest.php
@@ -1,8 +1,10 @@
 <?php
+namespace Particle\Tests\Rule;
+
 use Particle\Validator\Rule\Equal;
 use Particle\Validator\Validator;
 
-class EqualTest extends PHPUnit_Framework_TestCase
+class EqualTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Validator

--- a/tests/Particle/Validator/Rule/InArrayTest.php
+++ b/tests/Particle/Validator/Rule/InArrayTest.php
@@ -1,8 +1,10 @@
 <?php
+namespace Particle\Tests\Rule;
+
 use Particle\Validator\Rule\InArray;
 use Particle\Validator\Validator;
 
-class InArrayTest extends PHPUnit_Framework_TestCase
+class InArrayTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Validator

--- a/tests/Particle/Validator/Rule/IntegerTest.php
+++ b/tests/Particle/Validator/Rule/IntegerTest.php
@@ -1,8 +1,10 @@
 <?php
+namespace Particle\Tests\Rule;
+
 use Particle\Validator\Rule\Integer;
 use Particle\Validator\Validator;
 
-class IntegerTest extends PHPUnit_Framework_TestCase
+class IntegerTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Validator

--- a/tests/Particle/Validator/Rule/LengthBetweenTest.php
+++ b/tests/Particle/Validator/Rule/LengthBetweenTest.php
@@ -1,8 +1,10 @@
 <?php
+namespace Particle\Tests\Rule;
+
 use Particle\Validator\Rule\LengthBetween;
 use Particle\Validator\Validator;
 
-class LengthBetweenTest extends PHPUnit_Framework_TestCase
+class LengthBetweenTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Validator

--- a/tests/Particle/Validator/Rule/LengthTest.php
+++ b/tests/Particle/Validator/Rule/LengthTest.php
@@ -1,8 +1,10 @@
 <?php
+namespace Particle\Tests\Rule;
+
 use Particle\Validator\Rule\Length;
 use Particle\Validator\Validator;
 
-class LengthTest extends PHPUnit_Framework_TestCase
+class LengthTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Validator

--- a/tests/Particle/Validator/Rule/RegexTest.php
+++ b/tests/Particle/Validator/Rule/RegexTest.php
@@ -1,8 +1,10 @@
 <?php
+namespace Particle\Tests\Rule;
+
 use Particle\Validator\Rule\Regex;
 use Particle\Validator\Validator;
 
-class RegexTest extends PHPUnit_Framework_TestCase
+class RegexTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Validator

--- a/tests/Particle/Validator/Rule/UrlTest.php
+++ b/tests/Particle/Validator/Rule/UrlTest.php
@@ -1,8 +1,10 @@
 <?php
+namespace Particle\Tests\Rule;
+
 use Particle\Validator\Rule\Url;
 use Particle\Validator\Validator;
 
-class UrlTest extends PHPUnit_Framework_TestCase
+class UrlTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Validator

--- a/tests/Particle/Validator/Rule/UuidTest.php
+++ b/tests/Particle/Validator/Rule/UuidTest.php
@@ -1,8 +1,10 @@
 <?php
+namespace Particle\Tests\Rule;
+
 use Particle\Validator\Validator;
 use Particle\Validator\Rule\Uuid;
 
-class UuidV4Test extends PHPUnit_Framework_TestCase
+class UuidV4Test extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Validator

--- a/tests/Particle/Validator/RuleTest.php
+++ b/tests/Particle/Validator/RuleTest.php
@@ -1,9 +1,10 @@
 <?php
+namespace Particle\Tests;
 
 use Particle\Validator\Rule;
 use Particle\Validator\Value\Container;
 
-class RuleTest extends PHPUnit_Framework_TestCase
+class RuleTest extends \PHPUnit_Framework_TestCase
 {
     public function testUsesMessageStack()
     {

--- a/tests/Particle/Validator/ValidatorTest.php
+++ b/tests/Particle/Validator/ValidatorTest.php
@@ -1,12 +1,13 @@
 <?php
+namespace Particle\Tests;
+
 use Particle\Validator\MessageStack;
 use Particle\Validator\Rule;
 use Particle\Validator\Validator;
-
 use Particle\Validator\Rule\Required;
 use Particle\Validator\Value\Container;
 
-class ValidatorTest extends PHPUnit_Framework_TestCase
+class ValidatorTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Validator
@@ -122,7 +123,7 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testRequiredCanBeConditional()
     {
-        $this->validator->optional('first_name')->required(function(array $values) {
+        $this->validator->optional('first_name')->required(function (array $values) {
             return $values['foo'] === 'bar';
         });
 
@@ -145,7 +146,7 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testAllowEmptyCanBeConditional()
     {
-        $this->validator->required('first_name', 'first name', true)->allowEmpty(function($values) {
+        $this->validator->required('first_name', 'first name', true)->allowEmpty(function ($values) {
             return $values['foo'] !== 'bar';
         });
 


### PR DESCRIPTION
### What

To make sure the code style quality of the tests remains as good as it is, I now included the tests to be PSR-2 valid as well. Some changes where needed to make the code pass.

### How to test

1. Run `php vendor/bin/phpcs -n --standard=PSR2 --ignore=vendor .`, so that all code gets tested except for the vendor folder
1. See a green build with the new test command