### PR TITLE
Normalize the validation error messages and make them consistent

### DIFF
--- a/src/Particle/Validator/Rule/Alnum.php
+++ b/src/Particle/Validator/Rule/Alnum.php
@@ -38,7 +38,7 @@ class Alnum extends Regex
      * @var array
      */
     protected $messageTemplates = [
-        self::NOT_ALNUM => 'The value of "{{ name }}" can only consist out of numeric and alphabetic characters'
+        self::NOT_ALNUM => '{{ name }} may only consist out of numeric and alphabetic characters'
     ];
 
     /**

--- a/src/Particle/Validator/Rule/Alpha.php
+++ b/src/Particle/Validator/Rule/Alpha.php
@@ -38,7 +38,7 @@ class Alpha extends Regex
      * @var array
      */
     protected $messageTemplates = [
-        self::NOT_ALPHA => 'The value of "{{ name }}" can only consist out of alphabetic characters'
+        self::NOT_ALPHA => '{{ name }} may only consist out of alphabetic characters'
     ];
 
     /**

--- a/src/Particle/Validator/Rule/Between.php
+++ b/src/Particle/Validator/Rule/Between.php
@@ -28,7 +28,7 @@ class Between extends Rule
      * @var array
      */
     protected $messageTemplates = [
-        self::NOT_BETWEEN => 'Value of "{{ name }}" must be between {{ min }} and {{ max }}'
+        self::NOT_BETWEEN => '{{ name }} must be between {{ min }} and {{ max }}'
     ];
 
     /**

--- a/src/Particle/Validator/Rule/Callback.php
+++ b/src/Particle/Validator/Rule/Callback.php
@@ -30,7 +30,7 @@ class Callback extends Rule
      * @var array
      */
     protected $messageTemplates = [
-        self::INVALID_VALUE => 'The value of "{{ name }}" is invalid',
+        self::INVALID_VALUE => '{{ name }} is invalid',
     ];
 
     /**

--- a/src/Particle/Validator/Rule/Datetime.php
+++ b/src/Particle/Validator/Rule/Datetime.php
@@ -28,7 +28,7 @@ class Datetime extends Rule
      * @var array
      */
     protected $messageTemplates = [
-        self::INVALID_VALUE => 'The value of "{{ name }}" is not a valid date',
+        self::INVALID_VALUE => '{{ name }} must be a valid date',
     ];
 
     /**

--- a/src/Particle/Validator/Rule/Digits.php
+++ b/src/Particle/Validator/Rule/Digits.php
@@ -28,7 +28,7 @@ class Digits extends Rule
      * @var array
      */
     protected $messageTemplates = [
-        self::NOT_DIGITS => 'The value of "{{ name }}" must consist only out of digits',
+        self::NOT_DIGITS => '{{ name }} may only consist out of digits',
     ];
 
     /**

--- a/src/Particle/Validator/Rule/Email.php
+++ b/src/Particle/Validator/Rule/Email.php
@@ -28,7 +28,7 @@ class Email extends Rule
      * @var array
      */
     protected $messageTemplates = [
-        self::INVALID_FORMAT => 'The value of "{{ name }}" must be a valid email address',
+        self::INVALID_FORMAT => '{{ name }} must be a valid email address',
     ];
 
     /**

--- a/src/Particle/Validator/Rule/Equal.php
+++ b/src/Particle/Validator/Rule/Equal.php
@@ -28,7 +28,7 @@ class Equal extends Rule
      * @var array
      */
     protected $messageTemplates = [
-        self::NOT_EQUAL => 'The value of "{{ name }}" must be equal to "{{ testvalue }}"'
+        self::NOT_EQUAL => '{{ name }} must be equal to "{{ testvalue }}"'
     ];
 
     /**

--- a/src/Particle/Validator/Rule/InArray.php
+++ b/src/Particle/Validator/Rule/InArray.php
@@ -28,7 +28,7 @@ class InArray extends Rule
      * @var array
      */
     protected $messageTemplates = [
-        self::NOT_IN_ARRAY => 'The value of "{{ name }}" is not in the defined set of values',
+        self::NOT_IN_ARRAY => '{{ name }} must be in the defined set of values',
     ];
 
     protected $array = [];

--- a/src/Particle/Validator/Rule/Integer.php
+++ b/src/Particle/Validator/Rule/Integer.php
@@ -28,7 +28,7 @@ class Integer extends Rule
      * @var array
      */
     protected $messageTemplates = [
-        self::NOT_AN_INTEGER => 'The value of "{{ name }}" must represent an integer',
+        self::NOT_AN_INTEGER => '{{ name }} must be an integer',
     ];
 
     /**

--- a/src/Particle/Validator/Rule/Length.php
+++ b/src/Particle/Validator/Rule/Length.php
@@ -33,8 +33,8 @@ class Length extends Rule
      * @var array
      */
     protected $messageTemplates = [
-        self::TOO_SHORT => 'The value of "{{ name }}" is too short, should be {{ length }} characters long',
-        self::TOO_LONG => 'The value of "{{ name }}" is too long, should be {{ length }} characters long'
+        self::TOO_SHORT => '{{ name }} is too short and must be {{ length }} characters long',
+        self::TOO_LONG => '{{ name }} is too long and must be {{ length }} characters long',
     ];
 
     /**

--- a/src/Particle/Validator/Rule/LengthBetween.php
+++ b/src/Particle/Validator/Rule/LengthBetween.php
@@ -33,8 +33,8 @@ class LengthBetween extends Rule
      * @var array
      */
     protected $messageTemplates = [
-        self::TOO_LONG => 'The length of "{{ name }}" is too long, must be shorter than {{ max }} characters',
-        self::TOO_SHORT => 'The length of "{{ name }}" is too short, must be longer than {{ min}} characters'
+        self::TOO_LONG => '{{ name }} is too long and must be shorter than {{ max }} characters',
+        self::TOO_SHORT => '{{ name }} is too short and must be longer than {{ min }} characters'
     ];
 
     /**

--- a/src/Particle/Validator/Rule/Regex.php
+++ b/src/Particle/Validator/Rule/Regex.php
@@ -28,7 +28,7 @@ class Regex extends Rule
      * @var array
      */
     protected $messageTemplates = [
-        self::NO_MATCH => 'The value of "{{ name }}" is invalid'
+        self::NO_MATCH => '{{ name }} is invalid'
     ];
 
     /**

--- a/src/Particle/Validator/Rule/Required.php
+++ b/src/Particle/Validator/Rule/Required.php
@@ -35,8 +35,8 @@ class Required extends Rule
      * @var array
      */
     protected $messageTemplates = [
-        self::NON_EXISTENT_KEY => 'The key "{{ key }}" is required, but does not exist',
-        self::EMPTY_VALUE => 'The value of "{{ name }}" can not be empty'
+        self::NON_EXISTENT_KEY => '{{ key }} must be provided, but does not exist',
+        self::EMPTY_VALUE => '{{ name }} must be provided and may not be empty',
     ];
 
     /**

--- a/src/Particle/Validator/Rule/Url.php
+++ b/src/Particle/Validator/Rule/Url.php
@@ -28,7 +28,7 @@ class Url extends Rule
      * @var array
      */
     protected $messageTemplates = [
-        self::INVALID_URL => 'The value of "{{ name }}" must be a valid URL'
+        self::INVALID_URL => '{{ name }} must be a valid URL'
     ];
 
     /**

--- a/src/Particle/Validator/Rule/Uuid.php
+++ b/src/Particle/Validator/Rule/Uuid.php
@@ -42,7 +42,7 @@ class Uuid extends Regex
      * @var array
      */
     protected $messageTemplates = [
-        self::INVALID_UUID => 'The value of "{{ name }}" must be a valid UUID (v{{ version }})'
+        self::INVALID_UUID => '{{ name }} must be a valid UUID (v{{ version }})'
     ];
 
     /**

--- a/tests/Particle/Validator/Rule/AlnumTest.php
+++ b/tests/Particle/Validator/Rule/AlnumTest.php
@@ -94,7 +94,7 @@ class AlnumTest extends PHPUnit_Framework_TestCase
     public function getMessage($reason)
     {
         $messages = [
-            Alnum::NOT_ALNUM => 'The value of "first name" can only consist out of numeric and alphabetic characters'
+            Alnum::NOT_ALNUM => 'first name may only consist out of numeric and alphabetic characters'
         ];
 
         return $messages[$reason];

--- a/tests/Particle/Validator/Rule/AlphaTest.php
+++ b/tests/Particle/Validator/Rule/AlphaTest.php
@@ -94,7 +94,7 @@ class AlphaTest extends PHPUnit_Framework_TestCase
     public function getMessage($reason)
     {
         $messages = [
-            Alpha::NOT_ALPHA => 'The value of "first name" can only consist out of alphabetic characters',
+            Alpha::NOT_ALPHA => 'first name may only consist out of alphabetic characters',
         ];
 
         return $messages[$reason];

--- a/tests/Particle/Validator/Rule/BetweenTest.php
+++ b/tests/Particle/Validator/Rule/BetweenTest.php
@@ -78,7 +78,7 @@ class BetweenTest extends PHPUnit_Framework_TestCase
     public function getMessage($reason)
     {
         $messages = [
-            Between::NOT_BETWEEN => 'Value of "number" must be between 1 and 10'
+            Between::NOT_BETWEEN => 'number must be between 1 and 10'
         ];
 
         return $messages[$reason];

--- a/tests/Particle/Validator/Rule/CallbackTest.php
+++ b/tests/Particle/Validator/Rule/CallbackTest.php
@@ -80,7 +80,7 @@ class CallbackTest extends PHPUnit_Framework_TestCase
     public function getMessage($reason)
     {
         $messages = [
-            Callback::INVALID_VALUE => 'The value of "first name" is invalid'
+            Callback::INVALID_VALUE => 'first name is invalid'
         ];
 
         return $messages[$reason];

--- a/tests/Particle/Validator/Rule/DatetimeTest.php
+++ b/tests/Particle/Validator/Rule/DatetimeTest.php
@@ -25,7 +25,7 @@ class DatetimeTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($result);
         $expected = [
             'time' => [
-                \Particle\Validator\Rule\Datetime::INVALID_VALUE => 'The value of "time" is not a valid date'
+                \Particle\Validator\Rule\Datetime::INVALID_VALUE => 'time must be a valid date'
             ]
         ];
         $this->assertEquals($expected, $this->validator->getMessages());
@@ -47,7 +47,7 @@ class DatetimeTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($result);
         $expected = [
             'time' => [
-                \Particle\Validator\Rule\Datetime::INVALID_VALUE => 'The value of "time" is not a valid date'
+                \Particle\Validator\Rule\Datetime::INVALID_VALUE => 'time must be a valid date'
             ]
         ];
         $this->assertEquals($expected, $this->validator->getMessages());

--- a/tests/Particle/Validator/Rule/DigitsTest.php
+++ b/tests/Particle/Validator/Rule/DigitsTest.php
@@ -49,7 +49,7 @@ class DigitsTest extends PHPUnit_Framework_TestCase
     public function getMessage($reason)
     {
         $messages = [
-            Digits::NOT_DIGITS => 'The value of "digits" must consist only out of digits'
+            Digits::NOT_DIGITS => 'digits may only consist out of digits'
         ];
 
         return $messages[$reason];

--- a/tests/Particle/Validator/Rule/EmailTest.php
+++ b/tests/Particle/Validator/Rule/EmailTest.php
@@ -35,7 +35,7 @@ class EmailTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($this->validator->validate(['email' => $value]));
         $expected = [
             'email' => [
-                Email::INVALID_FORMAT => 'The value of "email" must be a valid email address'
+                Email::INVALID_FORMAT => 'email must be a valid email address'
             ]
         ];
         $this->assertEquals($expected, $this->validator->getMessages());

--- a/tests/Particle/Validator/Rule/EqualTest.php
+++ b/tests/Particle/Validator/Rule/EqualTest.php
@@ -28,7 +28,7 @@ class EqualTest extends PHPUnit_Framework_TestCase
 
         $expected = [
             'first_name' => [
-                Equal::NOT_EQUAL => 'The value of "first name" must be equal to "0"'
+                Equal::NOT_EQUAL => 'first name must be equal to "0"'
             ]
         ];
         $this->assertEquals($expected, $this->validator->getMessages());

--- a/tests/Particle/Validator/Rule/InArrayTest.php
+++ b/tests/Particle/Validator/Rule/InArrayTest.php
@@ -27,7 +27,7 @@ class InArrayTest extends PHPUnit_Framework_TestCase
 
         $expected = [
             'group' => [
-                InArray::NOT_IN_ARRAY => 'The value of "group" is not in the defined set of values'
+                InArray::NOT_IN_ARRAY => 'group must be in the defined set of values'
             ]
         ];
 
@@ -40,14 +40,14 @@ class InArrayTest extends PHPUnit_Framework_TestCase
 
         $this->validator->overwriteMessages([
             'group' => [
-                InArray::NOT_IN_ARRAY => 'The value of "{{ name }}" must be one of {{ values }}'
+                InArray::NOT_IN_ARRAY => '{{ name }} must be one of {{ values }}'
             ]
         ]);
         $this->assertFalse($this->validator->validate(['group' => 'none']));
 
         $expected = [
             'group' => [
-                InArray::NOT_IN_ARRAY => 'The value of "group" must be one of "users", "admins"'
+                InArray::NOT_IN_ARRAY => 'group must be one of "users", "admins"'
             ]
         ];
 

--- a/tests/Particle/Validator/Rule/IntegerTest.php
+++ b/tests/Particle/Validator/Rule/IntegerTest.php
@@ -65,7 +65,7 @@ class IntegerTest extends PHPUnit_Framework_TestCase
     public function getMessage($reason)
     {
         $messages = [
-            Integer::NOT_AN_INTEGER => 'The value of "integer" must represent an integer'
+            Integer::NOT_AN_INTEGER => 'integer must be an integer'
         ];
 
         return $messages[$reason];

--- a/tests/Particle/Validator/Rule/LengthBetweenTest.php
+++ b/tests/Particle/Validator/Rule/LengthBetweenTest.php
@@ -49,8 +49,8 @@ class LengthBetweenTest extends PHPUnit_Framework_TestCase
     public function getMessage($reason)
     {
         $messages = [
-            LengthBetween::TOO_SHORT => 'The length of "first name" is too short, must be longer than 2 characters',
-            LengthBetween::TOO_LONG => 'The length of "first name" is too long, must be shorter than 7 characters',
+            LengthBetween::TOO_SHORT => 'first name is too short and must be longer than 2 characters',
+            LengthBetween::TOO_LONG => 'first name is too long and must be shorter than 7 characters',
         ];
 
         return $messages[$reason];

--- a/tests/Particle/Validator/Rule/LengthTest.php
+++ b/tests/Particle/Validator/Rule/LengthTest.php
@@ -60,8 +60,8 @@ class LengthTest extends PHPUnit_Framework_TestCase
     public function getMessage($reason)
     {
         $messages = [
-            Length::TOO_SHORT => 'The value of "first name" is too short, should be 5 characters long',
-            Length::TOO_LONG => 'The value of "first name" is too long, should be 5 characters long',
+            Length::TOO_SHORT => 'first name is too short and must be 5 characters long',
+            Length::TOO_LONG => 'first name is too long and must be 5 characters long',
         ];
         return $messages[$reason];
     }

--- a/tests/Particle/Validator/Rule/RegexTest.php
+++ b/tests/Particle/Validator/Rule/RegexTest.php
@@ -27,7 +27,7 @@ class RegexTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($this->validator->validate(['first_name' => 'Berry']));
         $expected = [
             'first_name' => [
-                Regex::NO_MATCH => 'The value of "first name" is invalid'
+                Regex::NO_MATCH => 'first name is invalid'
             ]
         ];
 

--- a/tests/Particle/Validator/Rule/UrlTest.php
+++ b/tests/Particle/Validator/Rule/UrlTest.php
@@ -36,7 +36,7 @@ class UrlTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($this->validator->validate(['url' => $value]));
         $expected = [
             'url' => [
-                Url::INVALID_URL => 'The value of "url" must be a valid URL'
+                Url::INVALID_URL => 'url must be a valid URL'
             ]
         ];
         $this->assertEquals($expected, $this->validator->getMessages());

--- a/tests/Particle/Validator/Rule/UuidTest.php
+++ b/tests/Particle/Validator/Rule/UuidTest.php
@@ -28,7 +28,7 @@ class UuidV4Test extends PHPUnit_Framework_TestCase
 
         $expected = [
             'guid' => [
-                Uuid::INVALID_UUID => 'The value of "guid" must be a valid UUID (v4)'
+                Uuid::INVALID_UUID => 'guid must be a valid UUID (v4)'
             ]
         ];
 

--- a/tests/Particle/Validator/RuleTest.php
+++ b/tests/Particle/Validator/RuleTest.php
@@ -14,7 +14,7 @@ class RuleTest extends PHPUnit_Framework_TestCase
         $ms->shouldReceive('append')->withArgs([
             'key',
             Rule\Length::TOO_SHORT,
-            'The value of "{{ name }}" is too short, should be {{ length }} characters long',
+            '{{ name }} is too short and must be {{ length }} characters long',
             [
                 'key' => 'key',
                 'name' => 'name',

--- a/tests/Particle/Validator/ValidatorTest.php
+++ b/tests/Particle/Validator/ValidatorTest.php
@@ -28,7 +28,7 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             [
                 'first_name' => [
-                    Required::NON_EXISTENT_KEY => 'The key "first_name" is required, but does not exist',
+                    Required::NON_EXISTENT_KEY => 'first_name must be provided, but does not exist',
                 ]
             ],
             $this->validator->getMessages()
@@ -45,7 +45,7 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             [
                 'first_name' => [
-                    Required::NON_EXISTENT_KEY => 'The key "first_name" is required, but does not exist',
+                    Required::NON_EXISTENT_KEY => 'first_name must be provided, but does not exist',
                 ]
             ],
             $this->validator->getMessages()
@@ -62,7 +62,7 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             [
                 'first_name' => [
-                    Required::EMPTY_VALUE => 'The value of "first name" can not be empty'
+                    Required::EMPTY_VALUE => 'first name must be provided and may not be empty'
                 ]
             ],
             $this->validator->getMessages()
@@ -113,7 +113,7 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             [
                 'first_name' => [
-                    Required::EMPTY_VALUE => 'The value of "first name" can not be empty'
+                    Required::EMPTY_VALUE => 'first name must be provided and may not be empty'
                 ]
             ],
             $this->validator->getMessages()
@@ -132,7 +132,7 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             [
                 'first_name' => [
-                    Required::NON_EXISTENT_KEY => 'The key "first_name" is required, but does not exist',
+                    Required::NON_EXISTENT_KEY => 'first_name must be provided, but does not exist',
                 ]
             ],
             $this->validator->getMessages()
@@ -155,7 +155,7 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             [
                 'first_name' => [
-                    Required::EMPTY_VALUE => 'The value of "first name" can not be empty'
+                    Required::EMPTY_VALUE => 'first name must be provided and may not be empty'
                 ]
             ],
             $this->validator->getMessages()


### PR DESCRIPTION
### What

This PR changes the validation error messages and make them better understandable for the end-user.

All validation messages will use:

* `x` must be ...
* `x` may only consist out of ...
* `x` is invalid. 

### How to test

1. Check the adapted validation messages and make sure they are consistent
1. See that all tests pass with the new validation messages

### ToDo

* [x] Make all validation messages consistent

### Issue

https://github.com/particle-php/Validator/issues/27 