### PR TITLE
[bugfix] Required allowing empty wrongfully didn't accept a null value.

### DIFF
--- a/src/Particle/Validator/Value/Container.php
+++ b/src/Particle/Validator/Value/Container.php
@@ -40,7 +40,7 @@ class Container
      */
     public function has($key)
     {
-        return isset($this->values[$key]);
+        return array_key_exists($key, $this->values);
     }
 
     /**

--- a/tests/Particle/Validator/ValidatorTest.php
+++ b/tests/Particle/Validator/ValidatorTest.php
@@ -88,7 +88,6 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([], $this->validator->getMessages());
     }
 
-
     public function testReturnsTrueOnNonExistingOptionalKeyAllowingEmpty()
     {
         $this->validator->optional('first_name');

--- a/tests/Particle/Validator/ValidatorTest.php
+++ b/tests/Particle/Validator/ValidatorTest.php
@@ -79,6 +79,16 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([], $this->validator->getMessages());
     }
 
+    public function testReturnsTrueOnExistingRequiredNullKeyAllowingEmpty()
+    {
+        $this->validator->required('first_name', 'first name', true);
+        $result = $this->validator->validate(['first_name' => null]);
+
+        $this->assertTrue($result);
+        $this->assertEquals([], $this->validator->getMessages());
+    }
+
+
     public function testReturnsTrueOnNonExistingOptionalKeyAllowingEmpty()
     {
         $this->validator->optional('first_name');


### PR DESCRIPTION
## What?

The `required('foo', 'bar', true)` wrongfully didn't accept `['foo' => null]`. This has been fixed in this PR. See the tests for proof of the fix.