### PR TITLE
Adding validation result

### DIFF
--- a/docs/validation-result.md
+++ b/docs/validation-result.md
@@ -1,0 +1,45 @@
+# Using ValidationResult
+
+A lot of the times, your software will be split into separate layers, where each layer has its own
+responsibility (think about MVC, for example). The chances are that the layer that does the validation
+of incoming data is not the same that determines what to do next, or the layer that displays messages
+to a user.
+
+This is why Particle\Validator includes a ValidationResult class: so that you can pass that to other
+layers which will then determine what to do with the result. Usage of this class can not be any
+simpler:
+
+```php
+use Particle\Validator\ValidationResult;
+use Particle\Validator\Validator;
+
+class MyEntity 
+{
+    protected $id;
+    
+    public function setId($id)
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    public function validate() {
+        $v = new Validator;
+        
+        return new ValidationResult(
+            $v->validate($this->values)),
+            $v->getMessages()
+        );
+    }
+}
+
+// in a controller:
+$entity = new Entity();
+$entity->setId($this->getParam('id'));
+$result = $entity->validate();
+if (!$result->isValid()) {
+    return $this->renderTemplate([
+        'messages' => $result->getMessages() // or maybe even just pass in $result.
+    ]);
+}
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,4 +8,4 @@ pages:
 - [messages.md, Overwriting messages]
 - [contexts.md, Using contexts]
 - [extending.md, Extending the Validator]
-
+- [validation-result.md, Using ValidationResult]

--- a/src/Particle/Validator/Rule/InArray.php
+++ b/src/Particle/Validator/Rule/InArray.php
@@ -31,9 +31,16 @@ class InArray extends Rule
         self::NOT_IN_ARRAY => '{{ name }} must be in the defined set of values',
     ];
 
+    /**
+     * The array that contains the values to check.
+     *
+     * @var array
+     */
     protected $array = [];
 
     /**
+     * A bool denoting whether or not strict checking should be done.
+     *
      * @var bool
      */
     protected $strict;

--- a/src/Particle/Validator/ValidationResult.php
+++ b/src/Particle/Validator/ValidationResult.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/validator/blob/master/LICENSE New BSD License
+ */
+namespace Particle\Validator;
+
+/**
+ * The ValidationResult class is used when you want to communicate both result as messages to a different layer in your
+ * application.
+ *
+ * @package Particle\Validator
+ */
+class ValidationResult
+{
+    /**
+     * @var bool
+     */
+    protected $result;
+
+    /**
+     * @var array
+     */
+    protected $messages;
+
+    /**
+     * Construct the validation result.
+     *
+     * @param bool $result
+     * @param array $messages
+     */
+    public function __construct($result, array $messages)
+    {
+        $this->result = $result;
+        $this->messages = $messages;
+    }
+
+    /**
+     * Returns whether or not the validator has validated the values.
+     *
+     * @return bool
+     */
+    public function isValid()
+    {
+        return $this->result;
+    }
+
+    /**
+     * Returns the array of messages that were collected during validation.
+     *
+     * @return array
+     */
+    public function getMessages()
+    {
+        return $this->messages;
+    }
+}

--- a/tests/Particle/Validator/ValidationResultTest.php
+++ b/tests/Particle/Validator/ValidationResultTest.php
@@ -1,0 +1,22 @@
+<?php
+namespace Particle\Tests;
+
+use Particle\Validator\ValidationResult;
+use Particle\Validator\Rule\Alpha;
+
+class ValidationResultTest extends \PHPUnit_Framework_TestCase
+{
+    public function testReturnsResultAndMessages()
+    {
+        // lamest test ever, but then, the ValidationResult is only for convenience.
+        $messages = [
+            'first_name' => [
+                Alpha::NOT_ALPHA => 'first name may only consist out of alphabetical characters'
+            ]
+        ];
+
+        $result = new ValidationResult(false, $messages);
+        $this->assertFalse($result->isValid());
+        $this->assertEquals($messages, $result->getMessages());
+    }
+}

--- a/tests/Particle/Validator/ValidatorTest.php
+++ b/tests/Particle/Validator/ValidatorTest.php
@@ -1,11 +1,9 @@
 <?php
 namespace Particle\Tests;
 
-use Particle\Validator\MessageStack;
 use Particle\Validator\Rule;
 use Particle\Validator\Validator;
 use Particle\Validator\Rule\Required;
-use Particle\Validator\Value\Container;
 
 class ValidatorTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
## What

Adding a pretty simple `ValidationResult` class, which can contain both the result of validation as the error messages. This can be used to communicate the validation result among several layers of the application, without adding `getMessages()` proxy methods.