### PR TITLE
Validator should not show undefined index on unconfigured validator.

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -22,7 +22,9 @@ class Validator
      *
      * @var array
      */
-    protected $chains = [];
+    protected $chains = [
+        self::DEFAULT_CONTEXT => [],
+    ];
 
     /**
      * Contains an array of context => messages.

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -180,4 +180,9 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($result);
     }
+
+    public function testUnconfiguredValidatorWillNotShowNotice()
+    {
+        $this->assertTrue($this->validator->validate(['value' => 'yes']));
+    }
 }


### PR DESCRIPTION
## What?

See issue #53 for the bug report. An Validator without any rules would show a notice and a warning, because of the fact the default context wasn't added to the `$rules` array. This has now been fixed, see also the unit test supporting the fix.