### PR TITLE
Deprecate validate() and add isValid() and isNotValid()

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@
 ```php
 $v = new Validator;
 $v->required('first_name')->length(5);
-$v->validate(['first_name' => 'Berry']); // bool(true).
+$v->isValid(['first_name' => 'Berry']); // bool(true).
 
 $v->required('last_name')->length(10);
-$v->validate(['first_name' => 'Berry']); // bool(false).
+$v->isValid(['first_name' => 'Berry']); // bool(false).
 
 $v->getMessages(); // array with error messages.
 ```

--- a/docs/contexts.md
+++ b/docs/contexts.md
@@ -15,8 +15,8 @@ $v->context('update', function(Validator $context) {
     $context->optional('first_name')->lengthBetween(2, 30);
 });
 
-$v->validate([], 'update'); // bool(true)
-$v->validate([], 'insert'); // bool(false), because first_name is required.
+$v->isValid([], 'update'); // bool(true)
+$v->isValid([], 'insert'); // bool(false), because first_name is required.
 ```
 
 ## Copying from another context
@@ -41,7 +41,7 @@ $v->context('update', function(Validator $context) {
     $context->optional('first_name');
 });
 
-$v->validate([], 'update'); // bool(true)
+$v->isValid([], 'update'); // bool(true)
 ```
 
 ## Extended example of copying

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -81,7 +81,7 @@ class GrumpyRule extends Rule
         $this->who = $who;
     }
 
-    public function validate($value)
+    public function isValid($value)
     {
         if ($value !== null || $value === null) { // always true, so always grumpy!
             return $this->error(self::WRONG);
@@ -104,7 +104,7 @@ All that's left is actually using your own validator:
 ```php
 $v = new MyValidator;
 $v->required('foo')->grumpy('Silly sally');
-$v->validate(['foo' => true]);
+$v->isValid(['foo' => true]);
 
 // output: 'Silly Sally hates the value of "foo"'
 echo $v->getMessages()['foo'][Grumpy::WRONG]; 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -81,7 +81,7 @@ class GrumpyRule extends Rule
         $this->who = $who;
     }
 
-    public function isValid($value)
+    public function validate($value)
     {
         if ($value !== null || $value === null) { // always true, so always grumpy!
             return $this->error(self::WRONG);

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ $data = [
     'last_name' => 'Doe',
 ];
 
-$validator->validate($data); // bool(true)
+$validator->isValid($data); // bool(true)
 ```
 
 ## Why Particle\Validator?

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -19,7 +19,7 @@ $v->overwriteMessages([
     ]
 ]);
 
-$v->validate([
+$v->isValid([
     'first_name' => 'this is too long',
     'last_name' => 'this is also too long',
 ]);

--- a/docs/nested-values.md
+++ b/docs/nested-values.md
@@ -14,6 +14,6 @@ $values = [
 $v = new Validator;
 $v->required('user.username')->alpha();
 
-$v->validate($values); // bool(true)
+$v->isValid($values); // bool(true)
 $v->getValues() === $values; /// bool(true)
 ```

--- a/docs/required-optional.md
+++ b/docs/required-optional.md
@@ -13,33 +13,33 @@ A bit of code says more than a thousand words, so we'll cover all possible use-c
 
 ```php
 $v->required('foo')->lengthBetween(0, 100);
-$v->validate(['foo' => '']); // false, because allowEmpty is false by default.
+$v->isValid(['foo' => '']); // false, because allowEmpty is false by default.
 ```
 
 ### Validate a required value, which is allowed to be empty.
 
 ```php
 $v->required('foo', 'foo', true); // third parameter is "allowEmpty".
-$v->validate(['foo' => '']); // true, because allowEmpty is true.
+$v->isValid(['foo' => '']); // true, because allowEmpty is true.
 ```
 
 ### Validate an optional value, which is not allowed to be empty
 
 ```php
 $v->optional('foo')->lengthBetween(0, 100);
-$v->validate(['foo' => '']); // false, because allowEmpty is false and the key exists.
+$v->isValid(['foo' => '']); // false, because allowEmpty is false and the key exists.
 ```
 
 ### Validate a non-existing optional value, which is not allowed to be empty
 
 ```php
 $v->optional('foo')->lengthBetween(20, 100);
-$v->validate([]); // true, because the optional key is not present.
+$v->isValid([]); // true, because the optional key is not present.
 ```
 
 ### Validate an optional value, which is allowed to be empty.
 
 ```php
 $v->optional('foo', 'foo', true)->lengthBetween(0, 100);
-$v->validate(['foo' => '']); // true, because allowEmpty is true.
+$v->isValid(['foo' => '']); // true, because allowEmpty is true.
 ```

--- a/docs/validation-result.md
+++ b/docs/validation-result.md
@@ -23,12 +23,12 @@ class MyEntity
         return $this;
     }
     
-    public function validate() {
+    public function isValid() {
         $v = new Validator;
         $v->required('id')->integer();
         
         return new ValidationResult(
-            $v->validate($this->values())),
+            $v->isValid($this->values())),
             $v->getMessages()
         );
     }
@@ -45,7 +45,7 @@ class MyEntity
 $entity = new Entity();
 $entity->setId($this->getParam('id'));
 
-$result = $entity->validate();
+$result = $entity->isValid();
 
 if (!$result->isValid()) {
     return $this->renderTemplate([

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -286,7 +286,7 @@ class Chain
      * @param Container $output
      * @return bool
      */
-    public function validate(MessageStack $messageStack, Container $input, Container $output)
+    public function isValid(MessageStack $messageStack, Container $input, Container $output)
     {
         $valid = true;
         $output->set($this->key, $input->get($this->key));

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -101,8 +101,21 @@ class Validator
      * @param array $values
      * @param string $context
      * @return bool
+     * @deprecated use isValid() or isNotValid() instead
      */
     public function validate(array $values, $context = self::DEFAULT_CONTEXT)
+    {
+        return $this->isValid($values, $context);
+    }
+
+    /**
+     * Checks if the values in the $values array are valid.
+     *
+     * @param array $values
+     * @param string $context
+     * @return bool
+     */
+    public function isValid(array $values, $context = self::DEFAULT_CONTEXT)
     {
         $valid = true;
         $messageStack = $this->buildMessageStack($context);
@@ -114,6 +127,18 @@ class Validator
             $valid = $chain->validate($messageStack, $input, $this->output) && $valid;
         }
         return $valid;
+    }
+
+    /**
+     * Checks if the values in the $values array not valid.
+     *
+     * @param array $values
+     * @param string $context
+     * @return bool
+     */
+    public function isNotValid(array $values, $context = self::DEFAULT_CONTEXT)
+    {
+        return !$this->isValid($values, $context);
     }
 
     /**

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -124,13 +124,13 @@ class Validator
 
         foreach ($this->chains[$context] as $chain) {
             /** @var Chain $chain */
-            $valid = $chain->validate($messageStack, $input, $this->output) && $valid;
+            $valid = $chain->isValid($messageStack, $input, $this->output) && $valid;
         }
         return $valid;
     }
 
     /**
-     * Checks if the values in the $values array not valid.
+     * Checks if the values in the $values array are not valid.
      *
      * @param array $values
      * @param string $context

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -25,7 +25,7 @@ class ContextTest extends \PHPUnit_Framework_TestCase
 
         $this->validator->required('first_name')->length(3);
 
-        $result = $this->validator->validate(['first_name' => 'berry'], 'insert');
+        $result = $this->validator->isValid(['first_name' => 'berry'], 'insert');
 
         $this->assertTrue($result);
         $this->assertEquals([], $this->validator->getMessages());
@@ -49,7 +49,7 @@ class ContextTest extends \PHPUnit_Framework_TestCase
             ]
         ]);
 
-        $this->validator->validate(['first_name' => 'Rick'], 'insert');
+        $this->validator->isValid(['first_name' => 'Rick'], 'insert');
         $expected = [
             'first_name' => [
                 Rule\Length::TOO_SHORT => 'This is from inside the context.'
@@ -70,7 +70,7 @@ class ContextTest extends \PHPUnit_Framework_TestCase
             ]
         ]);
 
-        $this->validator->validate(['first_name' => 'Rick'], 'insert');
+        $this->validator->isValid(['first_name' => 'Rick'], 'insert');
 
         $expected = [
             'first_name' => [
@@ -97,7 +97,7 @@ class ContextTest extends \PHPUnit_Framework_TestCase
             $context->copyContext('insert');
         });
 
-        $this->assertFalse($this->validator->validate(['first_name' => 'Rick'], 'update'));
+        $this->assertFalse($this->validator->isValid(['first_name' => 'Rick'], 'update'));
 
         $expected = [
             'first_name' => [
@@ -124,7 +124,7 @@ class ContextTest extends \PHPUnit_Framework_TestCase
             });
         });
 
-        $this->assertTrue($this->validator->validate([], 'update'));
+        $this->assertTrue($this->validator->isValid([], 'update'));
     }
 
     public function testContextCopyClonesButDoesNotOverwrite()
@@ -144,6 +144,6 @@ class ContextTest extends \PHPUnit_Framework_TestCase
             });
         });
 
-        $this->assertFalse($this->validator->validate([], 'insert'));
+        $this->assertFalse($this->validator->isValid([], 'insert'));
     }
 }

--- a/tests/Rule/AlnumTest.php
+++ b/tests/Rule/AlnumTest.php
@@ -23,7 +23,7 @@ class AlnumTest extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueForValidValues($value)
     {
         $this->validator->required('first_name')->alnum();
-        $result = $this->validator->validate(['first_name' => $value]);
+        $result = $this->validator->isValid(['first_name' => $value]);
 
         $this->assertTrue($result);
         $this->assertEquals([], $this->validator->getMessages());
@@ -36,7 +36,7 @@ class AlnumTest extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueForValidValuesWithSpaces($value)
     {
         $this->validator->required('first_name')->alnum(true);
-        $result = $this->validator->validate(['first_name' => $value]);
+        $result = $this->validator->isValid(['first_name' => $value]);
 
         $this->assertTrue($result);
         $this->assertEquals([], $this->validator->getMessages());
@@ -49,7 +49,7 @@ class AlnumTest extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueForDifferentAlphabets($value)
     {
         $this->validator->required('first_name')->alnum(true);
-        $result = $this->validator->validate(['first_name' => $value]);
+        $result = $this->validator->isValid(['first_name' => $value]);
 
         $this->assertTrue($result);
         $this->assertEquals([], $this->validator->getMessages());
@@ -62,7 +62,7 @@ class AlnumTest extends \PHPUnit_Framework_TestCase
     public function testReturnsFalseForValuesWithSpaces($value, $errorReason)
     {
         $this->validator->required('first_name')->alnum();
-        $result = $this->validator->validate(['first_name' => $value]);
+        $result = $this->validator->isValid(['first_name' => $value]);
 
         $expected = ['first_name' => [$errorReason => $this->getMessage($errorReason)]];
 

--- a/tests/Rule/AlphaTest.php
+++ b/tests/Rule/AlphaTest.php
@@ -23,7 +23,7 @@ class AlphaTest extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueForValidValues($value)
     {
         $this->validator->required('first_name')->alpha();
-        $result = $this->validator->validate(['first_name' => $value]);
+        $result = $this->validator->isValid(['first_name' => $value]);
 
         $this->assertTrue($result);
         $this->assertEquals([], $this->validator->getMessages());
@@ -36,7 +36,7 @@ class AlphaTest extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueForValidValuesWithSpaces($value)
     {
         $this->validator->required('first_name')->alpha(true);
-        $result = $this->validator->validate(['first_name' => $value]);
+        $result = $this->validator->isValid(['first_name' => $value]);
 
         $this->assertTrue($result);
         $this->assertEquals([], $this->validator->getMessages());
@@ -49,7 +49,7 @@ class AlphaTest extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueForDifferentAlphabets($value)
     {
         $this->validator->required('first_name')->alpha(true);
-        $result = $this->validator->validate(['first_name' => $value]);
+        $result = $this->validator->isValid(['first_name' => $value]);
 
         $this->assertTrue($result);
         $this->assertEquals([], $this->validator->getMessages());
@@ -62,7 +62,7 @@ class AlphaTest extends \PHPUnit_Framework_TestCase
     public function testReturnsFalseForValuesWithSpaces($value, $errorReason)
     {
         $this->validator->required('first_name')->alpha();
-        $result = $this->validator->validate(['first_name' => $value]);
+        $result = $this->validator->isValid(['first_name' => $value]);
 
         $expected = ['first_name' => [$errorReason => $this->getMessage($errorReason)]];
 

--- a/tests/Rule/BetweenTest.php
+++ b/tests/Rule/BetweenTest.php
@@ -19,7 +19,7 @@ class BetweenTest extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueForValuesBetweenMinAndMax()
     {
         $this->validator->required('number')->between(1, 10);
-        $result = $this->validator->validate(['number' => 5]);
+        $result = $this->validator->isValid(['number' => 5]);
 
         $this->assertTrue($result);
         $this->assertEquals([], $this->validator->getMessages());
@@ -28,7 +28,7 @@ class BetweenTest extends \PHPUnit_Framework_TestCase
     public function testValidatesInclusiveByDefault()
     {
         $this->validator->required('number')->between(1, 10);
-        $result = $this->validator->validate(['number' => 1]);
+        $result = $this->validator->isValid(['number' => 1]);
 
         $this->assertTrue($result);
         $this->assertEquals([], $this->validator->getMessages());
@@ -37,7 +37,7 @@ class BetweenTest extends \PHPUnit_Framework_TestCase
     public function testReturnsFalseForValuesNotBetweenMinAndMaxLowerError()
     {
         $this->validator->required('number')->between(1, 10);
-        $result = $this->validator->validate(['number' => 0]);
+        $result = $this->validator->isValid(['number' => 0]);
 
         $expected = [
             'number' => [
@@ -51,7 +51,7 @@ class BetweenTest extends \PHPUnit_Framework_TestCase
     public function testReturnsFalseForValuesNotBetweenMinAndMaxUpperError()
     {
         $this->validator->required('number')->between(1, 10);
-        $result = $this->validator->validate(['number' => 11]);
+        $result = $this->validator->isValid(['number' => 11]);
 
         $expected = [
             'number' => [

--- a/tests/Rule/BoolTest.php
+++ b/tests/Rule/BoolTest.php
@@ -24,7 +24,7 @@ class BoolTest extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueOnlyOnValidBools($value, $expected)
     {
         $this->validator->required('active')->bool();
-        $result = $this->validator->validate(['active' => $value]);
+        $result = $this->validator->isValid(['active' => $value]);
         $this->assertEquals($expected, $result);
 
         if ($expected === false) {

--- a/tests/Rule/CallbackTest.php
+++ b/tests/Rule/CallbackTest.php
@@ -23,7 +23,7 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
             return $value === 'berry';
         });
 
-        $result = $this->validator->validate(['first_name' => 'berry']);
+        $result = $this->validator->isValid(['first_name' => 'berry']);
         $this->assertTrue($result);
     }
 
@@ -33,7 +33,7 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
             return $value !== 'berry';
         });
 
-        $result = $this->validator->validate(['first_name' => 'berry']);
+        $result = $this->validator->isValid(['first_name' => 'berry']);
         $this->assertFalse($result);
 
         $expected = [
@@ -57,7 +57,7 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
             return true;
         });
 
-        $result = $this->validator->validate(['first_name' => 'bill']);
+        $result = $this->validator->isValid(['first_name' => 'bill']);
         $this->assertFalse($result);
 
         $expected = [
@@ -75,7 +75,7 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
             return $context['last_name'] === 'Langerak' && $value === 'Berry';
         });
 
-        $result = $this->validator->validate(['first_name' => 'Berry', 'last_name' => 'Langerak']);
+        $result = $this->validator->isValid(['first_name' => 'Berry', 'last_name' => 'Langerak']);
         $this->assertTrue($result);
     }
 

--- a/tests/Rule/DatetimeTest.php
+++ b/tests/Rule/DatetimeTest.php
@@ -19,12 +19,12 @@ class DatetimeTest extends \PHPUnit_Framework_TestCase
     public function testRespectsFormatIfPassed()
     {
         $this->validator->required('time')->datetime('H:i');
-        $result = $this->validator->validate(['time' => '18:00']);
+        $result = $this->validator->isValid(['time' => '18:00']);
 
         $this->assertEquals([], $this->validator->getMessages());
         $this->assertTrue($result);
 
-        $result = $this->validator->validate(['time' => (new DateTime())->format('Y-m-d H:i:s')]);
+        $result = $this->validator->isValid(['time' => (new DateTime())->format('Y-m-d H:i:s')]);
 
         $this->assertFalse($result);
         $expected = [
@@ -38,15 +38,15 @@ class DatetimeTest extends \PHPUnit_Framework_TestCase
     public function testWillTakeManyFormatsIfNoFormatPassed()
     {
         $this->validator->required('time')->datetime();
-        $this->assertTrue($this->validator->validate(['time' => '18:00']));
-        $this->assertTrue($this->validator->validate(['time' => '2015-03-29 16:11:09']));
-        $this->assertTrue($this->validator->validate(['time' => '29-03-2015 16:11:09']));
+        $this->assertTrue($this->validator->isValid(['time' => '18:00']));
+        $this->assertTrue($this->validator->isValid(['time' => '2015-03-29 16:11:09']));
+        $this->assertTrue($this->validator->isValid(['time' => '29-03-2015 16:11:09']));
     }
 
     public function testReturnsFalseOnUnparsableDate()
     {
         $this->validator->required('time')->datetime();
-        $result = $this->validator->validate(['time' => 'This is not a date. Not even close.']);
+        $result = $this->validator->isValid(['time' => 'This is not a date. Not even close.']);
 
         $this->assertFalse($result);
         $expected = [
@@ -64,7 +64,7 @@ class DatetimeTest extends \PHPUnit_Framework_TestCase
     public function testReturnsFalseOnParsableButValidFormat()
     {
         $this->validator->required('date')->datetime('Ymd');
-        $result = $this->validator->validate([
+        $result = $this->validator->isValid([
             'date' => '12111978',
         ]);
 

--- a/tests/Rule/DigitsTest.php
+++ b/tests/Rule/DigitsTest.php
@@ -19,7 +19,7 @@ class DigitsTest extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueOnOnlyDigitCharacters()
     {
         $this->validator->required('digits')->digits();
-        $this->assertTrue($this->validator->validate(['digits' => '123456789']));
+        $this->assertTrue($this->validator->isValid(['digits' => '123456789']));
     }
 
     /**
@@ -29,7 +29,7 @@ class DigitsTest extends \PHPUnit_Framework_TestCase
     public function testReturnsFalseOnNonDigitCharacters($value)
     {
         $this->validator->required('digits')->digits();
-        $this->assertFalse($this->validator->validate(['digits' => $value]));
+        $this->assertFalse($this->validator->isValid(['digits' => $value]));
 
         $expected = [
             'digits' => [

--- a/tests/Rule/EmailTest.php
+++ b/tests/Rule/EmailTest.php
@@ -24,7 +24,7 @@ class EmailTest extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueOnValidEmailaddresses($value)
     {
         $this->validator->required('email')->email();
-        $this->assertTrue($this->validator->validate(['email' => $value]));
+        $this->assertTrue($this->validator->isValid(['email' => $value]));
     }
 
     /**
@@ -34,7 +34,7 @@ class EmailTest extends \PHPUnit_Framework_TestCase
     public function testReturnsFalseOnInvalidEmailaddresses($value)
     {
         $this->validator->required('email')->email();
-        $this->assertFalse($this->validator->validate(['email' => $value]));
+        $this->assertFalse($this->validator->isValid(['email' => $value]));
         $expected = [
             'email' => [
                 Email::INVALID_FORMAT => 'email must be a valid email address'

--- a/tests/Rule/EqualTest.php
+++ b/tests/Rule/EqualTest.php
@@ -19,14 +19,14 @@ class EqualTest extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueOnEqualValue()
     {
         $this->validator->required('first_name')->equals('berry');
-        $this->assertTrue($this->validator->validate(['first_name' => 'berry']));
+        $this->assertTrue($this->validator->isValid(['first_name' => 'berry']));
     }
 
     public function testReturnsFalseOnNonEqualValue()
     {
         $this->validator->required('first_name')->equals(0);
-        $this->assertFalse($this->validator->validate(['first_name' => '0'])); // strict typing all the way!
-        $this->assertFalse($this->validator->validate(['first_name' => 'No cigar, and not even close.']));
+        $this->assertFalse($this->validator->isValid(['first_name' => '0'])); // strict typing all the way!
+        $this->assertFalse($this->validator->isValid(['first_name' => 'No cigar, and not even close.']));
 
         $expected = [
             'first_name' => [

--- a/tests/Rule/InArrayTest.php
+++ b/tests/Rule/InArrayTest.php
@@ -19,13 +19,13 @@ class InArrayTest extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueIfValueIsInArrayWithStrictChecking()
     {
         $this->validator->required('group')->inArray(['foo', 'bar']);
-        $this->assertTrue($this->validator->validate(['group' => 'foo']));
+        $this->assertTrue($this->validator->isValid(['group' => 'foo']));
     }
 
     public function testReturnsFalseIfValueIsNotInArrayWithStrictChecking()
     {
         $this->validator->required('group')->inArray([0]);
-        $this->assertFalse($this->validator->validate(['group' => '0']));
+        $this->assertFalse($this->validator->isValid(['group' => '0']));
 
         $expected = [
             'group' => [
@@ -45,7 +45,7 @@ class InArrayTest extends \PHPUnit_Framework_TestCase
                 InArray::NOT_IN_ARRAY => '{{ name }} must be one of {{ values }}'
             ]
         ]);
-        $this->assertFalse($this->validator->validate(['group' => 'none']));
+        $this->assertFalse($this->validator->isValid(['group' => 'none']));
 
         $expected = [
             'group' => [
@@ -59,6 +59,6 @@ class InArrayTest extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueIfValueIsSortOfInArrayWithoutStrictChecking()
     {
         $this->validator->required('group')->inArray([0], false);
-        $this->assertTrue($this->validator->validate(['group' => '0']));
+        $this->assertTrue($this->validator->isValid(['group' => '0']));
     }
 }

--- a/tests/Rule/IntegerTest.php
+++ b/tests/Rule/IntegerTest.php
@@ -23,7 +23,7 @@ class IntegerTest extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueOnValidInteger($value)
     {
         $this->validator->required('integer')->integer();
-        $this->assertTrue($this->validator->validate(['integer' => $value]));
+        $this->assertTrue($this->validator->isValid(['integer' => $value]));
     }
 
     /**
@@ -33,7 +33,7 @@ class IntegerTest extends \PHPUnit_Framework_TestCase
     public function testReturnsFalseOnInvalidIntegers($value)
     {
         $this->validator->required('integer')->integer();
-        $this->assertFalse($this->validator->validate(['integer' => $value]));
+        $this->assertFalse($this->validator->isValid(['integer' => $value]));
 
         $expected = [
             'integer' => [

--- a/tests/Rule/LengthBetweenTest.php
+++ b/tests/Rule/LengthBetweenTest.php
@@ -19,22 +19,22 @@ class LengthBetweenTest extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueIfLengthIsExactlyMinOrMax()
     {
         $this->validator->required('first_name')->lengthBetween(2, 7);
-        $this->assertTrue($this->validator->validate(['first_name' => 'ad']));
-        $this->assertTrue($this->validator->validate(['first_name' => 'Richard']));
+        $this->assertTrue($this->validator->isValid(['first_name' => 'ad']));
+        $this->assertTrue($this->validator->isValid(['first_name' => 'Richard']));
         $this->assertEquals([], $this->validator->getMessages());
     }
 
     public function testReturnsTrueIfMaxIsNull()
     {
         $this->validator->required('password')->lengthBetween(2, null);
-        $this->assertTrue($this->validator->validate(['password' => str_repeat('foo', 100)]));
+        $this->assertTrue($this->validator->isValid(['password' => str_repeat('foo', 100)]));
         $this->assertEquals([], $this->validator->getMessages());
     }
 
     public function testReturnsFalseIfInvalid()
     {
         $this->validator->required('first_name')->lengthBetween(3, 6);
-        $result = $this->validator->validate(['first_name' => 'ad']);
+        $result = $this->validator->isValid(['first_name' => 'ad']);
 
         $this->assertFalse($result);
 
@@ -45,7 +45,7 @@ class LengthBetweenTest extends \PHPUnit_Framework_TestCase
         ];
         $this->assertEquals($expected, $this->validator->getMessages());
 
-        $result = $this->validator->validate(['first_name' => 'Richard']);
+        $result = $this->validator->isValid(['first_name' => 'Richard']);
 
         $this->assertFalse($result);
         $expected = [

--- a/tests/Rule/LengthTest.php
+++ b/tests/Rule/LengthTest.php
@@ -24,7 +24,7 @@ class LengthTest extends \PHPUnit_Framework_TestCase
     public function testInvalidValuesWillReturnFalseAndLogError($value, $error)
     {
         $this->validator->required('first_name')->length(5);
-        $result = $this->validator->validate(['first_name' => $value]);
+        $result = $this->validator->isValid(['first_name' => $value]);
 
         $expected = ['first_name' => [$error => $this->getMessage($error)]];
         $this->assertFalse($result);
@@ -38,7 +38,7 @@ class LengthTest extends \PHPUnit_Framework_TestCase
     public function testValidValuesWillReturnTrue($value)
     {
         $this->validator->required('first_name')->length(5);
-        $result = $this->validator->validate(['first_name' => $value]);
+        $result = $this->validator->isValid(['first_name' => $value]);
 
         $this->assertTrue($result);
     }

--- a/tests/Rule/NotEmptyTest.php
+++ b/tests/Rule/NotEmptyTest.php
@@ -23,7 +23,7 @@ class NotEmptyTest extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueOnNonEmptyValues($value)
     {
         $this->validator->optional('foo', 'foo', false);
-        $result = $this->validator->validate(['foo' => $value]);
+        $result = $this->validator->isValid(['foo' => $value]);
 
         $this->assertTrue($result);
     }
@@ -34,7 +34,7 @@ class NotEmptyTest extends \PHPUnit_Framework_TestCase
     public function testReturnsFalseOnEmptyValues($value)
     {
         $this->validator->optional('foo', 'foo', false);
-        $result = $this->validator->validate(['foo' => $value]);
+        $result = $this->validator->isValid(['foo' => $value]);
 
         $this->assertFalse($result);
         $this->assertArrayHasKey(NotEmpty::EMPTY_VALUE, $this->validator->getMessages()['foo']);
@@ -44,7 +44,7 @@ class NotEmptyTest extends \PHPUnit_Framework_TestCase
     {
         $this->validator->required('foo', 'foo', true)->length(5);
 
-        $result = $this->validator->validate([
+        $result = $this->validator->isValid([
             'foo' => null,
         ]);
 
@@ -58,7 +58,7 @@ class NotEmptyTest extends \PHPUnit_Framework_TestCase
             return $values['foo'] !== 'bar';
         });
 
-        $result = $this->validator->validate(['foo' => 'bar', 'first_name' => '']);
+        $result = $this->validator->isValid(['foo' => 'bar', 'first_name' => '']);
 
         $this->assertFalse($result);
         $this->assertEquals(
@@ -70,7 +70,7 @@ class NotEmptyTest extends \PHPUnit_Framework_TestCase
             $this->validator->getMessages()
         );
 
-        $result = $this->validator->validate(['foo' => 'not bar!', 'first_name' => '']);
+        $result = $this->validator->isValid(['foo' => 'not bar!', 'first_name' => '']);
         $this->assertTrue($result);
         $this->assertEquals([], $this->validator->getMessages());
     }

--- a/tests/Rule/RegexTest.php
+++ b/tests/Rule/RegexTest.php
@@ -19,14 +19,14 @@ class RegexTest extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueWhenMatchesRegex()
     {
         $this->validator->required('first_name')->regex('/^berry$/i');
-        $this->assertTrue($this->validator->validate(['first_name' => 'Berry']));
+        $this->assertTrue($this->validator->isValid(['first_name' => 'Berry']));
         $this->assertEquals([], $this->validator->getMessages());
     }
 
     public function testReturnsFalseOnNoMatch()
     {
         $this->validator->required('first_name')->regex('~this wont match~');
-        $this->assertFalse($this->validator->validate(['first_name' => 'Berry']));
+        $this->assertFalse($this->validator->isValid(['first_name' => 'Berry']));
         $expected = [
             'first_name' => [
                 Regex::NO_MATCH => 'first name is invalid'

--- a/tests/Rule/RequiredTest.php
+++ b/tests/Rule/RequiredTest.php
@@ -20,7 +20,7 @@ class RequiredTest extends \PHPUnit_Framework_TestCase
     {
         $this->validator->required('foo');
 
-        $result = $this->validator->validate([
+        $result = $this->validator->isValid([
         ]);
 
         $this->assertFalse($result);
@@ -29,7 +29,7 @@ class RequiredTest extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueOnSetRequiredValues()
     {
         $this->validator->required('foo');
-        $result = $this->validator->validate([
+        $result = $this->validator->isValid([
             'foo' => 'bar'
         ]);
         $this->assertTrue($result);
@@ -42,7 +42,7 @@ class RequiredTest extends \PHPUnit_Framework_TestCase
         $this->validator->required('foo');
 
         foreach ($values as $value) {
-            $this->validator->validate(['foo' => $value]);
+            $this->validator->isValid(['foo' => $value]);
 
             $this->assertArrayNotHasKey(
                 Required::NON_EXISTENT_KEY,
@@ -57,7 +57,7 @@ class RequiredTest extends \PHPUnit_Framework_TestCase
             return $values['foo'] === 'bar';
         });
 
-        $result = $this->validator->validate(['foo' => 'bar']);
+        $result = $this->validator->isValid(['foo' => 'bar']);
 
         $this->assertFalse($result);
         $this->assertEquals(
@@ -69,7 +69,7 @@ class RequiredTest extends \PHPUnit_Framework_TestCase
             $this->validator->getMessages()
         );
 
-        $result = $this->validator->validate(['foo' => 'not bar!']);
+        $result = $this->validator->isValid(['foo' => 'not bar!']);
         $this->assertTrue($result);
         $this->assertEquals([], $this->validator->getMessages());
     }

--- a/tests/Rule/UrlTest.php
+++ b/tests/Rule/UrlTest.php
@@ -23,7 +23,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueOnValidUrls($value)
     {
         $this->validator->required('url')->url();
-        $this->assertTrue($this->validator->validate(['url' => $value]));
+        $this->assertTrue($this->validator->isValid(['url' => $value]));
         $this->assertEquals([], $this->validator->getMessages());
     }
 
@@ -35,7 +35,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     public function testReturnsFalseOnInvalidUrls($value, $error)
     {
         $this->validator->required('url')->url();
-        $this->assertFalse($this->validator->validate(['url' => $value]));
+        $this->assertFalse($this->validator->isValid(['url' => $value]));
         $expected = [
             'url' => [
                 Url::INVALID_URL => 'url must be a valid URL'

--- a/tests/Rule/UuidTest.php
+++ b/tests/Rule/UuidTest.php
@@ -19,14 +19,14 @@ class UuidV4Test extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueWhenMatchesUuidV4()
     {
         $this->validator->required('guid')->uuid();
-        $this->assertTrue($this->validator->validate(['guid' => '44c0ffee-988a-49dc-0bad-a55c0de2d1e4']));
+        $this->assertTrue($this->validator->isValid(['guid' => '44c0ffee-988a-49dc-0bad-a55c0de2d1e4']));
         $this->assertEquals([], $this->validator->getMessages());
     }
 
     public function testReturnsFalseOnNoMatch()
     {
         $this->validator->required('guid')->uuid();
-        $this->assertFalse($this->validator->validate(['guid' => 'xxc0ffee-988a-49dc-0bad-a55c0de2d1e4']));
+        $this->assertFalse($this->validator->isValid(['guid' => 'xxc0ffee-988a-49dc-0bad-a55c0de2d1e4']));
 
         $expected = [
             'guid' => [

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -26,7 +26,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
             ]
         ]);
 
-        $this->assertFalse($this->validator->validate([]));
+        $this->assertFalse($this->validator->isValid([]));
         $this->assertEquals(
             [
                 'foo' => [
@@ -42,7 +42,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->validator->required('foo');
         $this->validator->optional('foo');
 
-        $result = $this->validator->validate([]);
+        $result = $this->validator->isValid([]);
 
         $this->assertTrue($result);
     }
@@ -54,7 +54,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $this->validator->required('first_name', 'Voornaam')->length(5);
-        $this->assertFalse($this->validator->validate(['first_name' => 'Rick']));
+        $this->assertFalse($this->validator->isValid(['first_name' => 'Rick']));
 
         $expected = [
             'first_name' => [
@@ -78,7 +78,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $this->validator->required('first_name')->length(5);
-        $this->assertFalse($this->validator->validate(['first_name' => 'Rick']));
+        $this->assertFalse($this->validator->isValid(['first_name' => 'Rick']));
 
         $expected = [
             'first_name' => [
@@ -94,7 +94,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->validator->required('first_name')->lengthBetween(2, 20);
         $this->validator->required('last_name')->lengthBetween(2, 60);
 
-        $this->validator->validate([
+        $this->validator->isValid([
             'first_name' => 'Berry',
             'last_name' => 'Langerak',
             'is_admin' => true
@@ -111,7 +111,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
     public function testNoFalsePositivesForIssetOnFalse()
     {
         $this->validator->required('falsy_value');
-        $result = $this->validator->validate([
+        $result = $this->validator->isValid([
             'falsy_value' => false,
         ]);
 
@@ -129,7 +129,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
     {
         $this->validator->required('user.contact.email')->email();
 
-        $result = $this->validator->validate([
+        $result = $this->validator->isValid([
             'user' => [
                 'contact' => [
                     'email' => 'example@particle-php.com'
@@ -143,7 +143,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
     public function testDotNotationIsAddedToMessagesVerbatim()
     {
         $this->validator->required('user.email');
-        $result = $this->validator->validate([]);
+        $result = $this->validator->isValid([]);
 
         $expected = [
             'user.email' => [
@@ -164,7 +164,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         ];
 
         $this->validator->required('user.email');
-        $this->validator->validate($input);
+        $this->validator->isValid($input);
         $this->assertEquals($input, $this->validator->getValues());
     }
 
@@ -172,7 +172,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
     {
         $this->validator->required('user.email', 'user email address', true);
 
-        $result = $this->validator->validate([
+        $result = $this->validator->isValid([
             'user' => [
                 'email' => null,
             ]
@@ -183,6 +183,33 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testUnconfiguredValidatorWillNotShowNotice()
     {
-        $this->assertTrue($this->validator->validate(['value' => 'yes']));
+        $this->assertTrue($this->validator->isValid(['value' => 'yes']));
+    }
+
+    public function testIsNotValid()
+    {
+        $this->validator->required('first_name')->lengthBetween(2, 20);
+        $this->validator->required('last_name')->lengthBetween(2, 20);
+
+        $this->assertTrue($this->validator->isNotValid([
+            'first_name' => 'Berry',
+            'last_name' => 'Langelangelangelangelangerak',
+        ]));
+    }
+
+    /**
+     * Test if the deprecated function still works, should get dropped in version 2 though.
+     */
+    public function testDeprecatedValidate()
+    {
+        $this->validator->required('first_name')->lengthBetween(2, 20);
+        $this->validator->required('last_name')->lengthBetween(2, 60);
+
+        $isValid = $this->validator->validate([
+            'first_name' => 'Berry',
+            'last_name' => 'Langerak',
+        ]);
+
+        $this->assertTrue($isValid);
     }
 }


### PR DESCRIPTION
### What

To have better readable code, we decided it would be better to rename `validate()` to `isValid()`. Also adding `isNotValid()` was requested. Since the Validator API is still visible in one auto-completion popup, I think it won't be a problem to add it.

### ToDo

* [ ] Make sure that we want to add `isNotValid()`
* [x] Update documentation

### How to test

1. See that all tests pass with the new `isValid()` function
1. See that `validate()` still works, but is now deprecated
1. See that the documentation now also uses `isValid()`