### PR TITLE
Feature: Result a validation result

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,23 @@
 
 ```php
 $v = new Validator;
+
 $v->required('first_name')->length(5);
-$v->validate(['first_name' => 'Berry']); // bool(true).
 
-$v->required('last_name')->length(10);
-$v->validate(['first_name' => 'Berry']); // bool(false).
+$result = $v->validate(['first_name' => 'Berry']);
+$result->isValid(); // bool(true).
+$result->getMessages(); // array(0)
 
-$v->getMessages(); // array with error messages.
+$result = $v->validate(['first_name' => 'Rick']);
+$result->isValid(); // bool(false).
+$result->getMessages();
+/**
+ * array(1) {
+ *     ["first_name"]=> array(1) {
+ *         ["Length::TOO_SHORT"]=> string(53) "first_name is too short and must be 5 characters long"
+ *     }
+ * }
+ */
 ```
 
 ## Features

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,13 @@
             "role": "developer"
         },
         {
-            "name": "Rick van der Staaij"
+            "name": "Rick van der Staaij",
+            "homepage": "http://rickvanderstaaij.nl",
+            "role": "Developer"
         }
     ],
     "require": {
-        "php": ">=5.3.2"
+        "php": ">=5.4"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",

--- a/docs/contexts.md
+++ b/docs/contexts.md
@@ -15,8 +15,8 @@ $v->context('update', function(Validator $context) {
     $context->optional('first_name')->lengthBetween(2, 30);
 });
 
-$v->validate([], 'update'); // bool(true)
-$v->validate([], 'insert'); // bool(false), because first_name is required.
+$v->validate([], 'update')->isValid(); // bool(true)
+$v->validate([], 'insert')->isValid(); // bool(false), because first_name is required.
 ```
 
 ## Copying from another context
@@ -41,7 +41,8 @@ $v->context('update', function(Validator $context) {
     $context->optional('first_name');
 });
 
-$v->validate([], 'update'); // bool(true)
+$result = $v->validate([], 'update');
+$result->isValid(); // bool(true)
 ```
 
 ## Extended example of copying

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -104,10 +104,10 @@ All that's left is actually using your own validator:
 ```php
 $v = new MyValidator;
 $v->required('foo')->grumpy('Silly sally');
-$v->validate(['foo' => true]);
+$result = $v->validate(['foo' => true]);
 
 // output: 'Silly Sally hates the value of "foo"'
-echo $v->getMessages()['foo'][Grumpy::WRONG]; 
+echo $result->getMessages()['foo'][Grumpy::WRONG]; 
 ```
 
 That's that: you can now go wild on adding rules. If you think a rule should be added to the main

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,8 @@ $data = [
     'last_name' => 'Doe',
 ];
 
-$validator->validate($data); // bool(true)
+$result = $validator->validate($data);
+$result->isValid(); // bool(true)
 ```
 
 ## Why Particle\Validator?

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -19,7 +19,7 @@ $v->overwriteMessages([
     ]
 ]);
 
-$v->validate([
+$result = $v->validate([
     'first_name' => 'this is too long',
     'last_name' => 'this is also too long',
 ]);
@@ -37,6 +37,5 @@ $v->validate([
  *     ]
  * ];
  */
-
-var_dump($v->getMessages());
+var_dump($result->getMessages());
 ```

--- a/docs/nested-values.md
+++ b/docs/nested-values.md
@@ -14,6 +14,6 @@ $values = [
 $v = new Validator;
 $v->required('user.username')->alpha();
 
-$v->validate($values); // bool(true)
-$v->getValues() === $values; /// bool(true)
+$result = $v->validate($values);
+$result->getValues() === $values; // bool(true)
 ```

--- a/docs/required-optional.md
+++ b/docs/required-optional.md
@@ -13,33 +13,33 @@ A bit of code says more than a thousand words, so we'll cover all possible use-c
 
 ```php
 $v->required('foo')->lengthBetween(0, 100);
-$v->validate(['foo' => '']); // false, because allowEmpty is false by default.
+$v->validate(['foo' => ''])->isValid(); // false, because allowEmpty is false by default.
 ```
 
 ### Validate a required value, which is allowed to be empty.
 
 ```php
 $v->required('foo', 'foo', true); // third parameter is "allowEmpty".
-$v->validate(['foo' => '']); // true, because allowEmpty is true.
+$v->validate(['foo' => ''])->isValid(); // true, because allowEmpty is true.
 ```
 
 ### Validate an optional value, which is not allowed to be empty
 
 ```php
 $v->optional('foo')->lengthBetween(0, 100);
-$v->validate(['foo' => '']); // false, because allowEmpty is false and the key exists.
+$v->validate(['foo' => ''])->isValid(); // false, because allowEmpty is false and the key exists.
 ```
 
 ### Validate a non-existing optional value, which is not allowed to be empty
 
 ```php
 $v->optional('foo')->lengthBetween(20, 100);
-$v->validate([]); // true, because the optional key is not present.
+$v->validate([])->isValid(); // true, because the optional key is not present.
 ```
 
 ### Validate an optional value, which is allowed to be empty.
 
 ```php
 $v->optional('foo', 'foo', true)->lengthBetween(0, 100);
-$v->validate(['foo' => '']); // true, because allowEmpty is true.
+$v->validate(['foo' => ''])->isValid(); // true, because allowEmpty is true.
 ```

--- a/docs/validation-result.md
+++ b/docs/validation-result.md
@@ -1,11 +1,11 @@
-# Using ValidationResult
+# ValidationResult
 
 A lot of the times, your software will be split into separate layers, where each layer has its own
 responsibility (think about MVC, for example). The chances are that the layer that does the validation
 of incoming data is not the same that determines what to do next, or the layer that displays messages
 to a user.
 
-This is why Particle\Validator includes a ValidationResult class: so that you can pass that to other
+This is why Particle\Validator results a ValidationResult class: so that you can pass that to other
 layers which will then determine what to do with the result. Usage of this class can not be any
 simpler:
 
@@ -27,10 +27,7 @@ class MyEntity
         $v = new Validator;
         $v->required('id')->integer();
         
-        return new ValidationResult(
-            $v->validate($this->values())),
-            $v->getMessages()
-        );
+        return new $v->validate($this->values());
     }
     
     protected function values()

--- a/src/ValidationResult.php
+++ b/src/ValidationResult.php
@@ -9,8 +9,7 @@
 namespace Particle\Validator;
 
 /**
- * The ValidationResult class is used when you want to communicate both result as messages to a different layer in your
- * application.
+ * The ValidationResult class holds the validation result and the validation messages.
  *
  * @package Particle\Validator
  */
@@ -19,7 +18,7 @@ class ValidationResult
     /**
      * @var bool
      */
-    protected $result;
+    protected $isValid;
 
     /**
      * @var array
@@ -27,15 +26,22 @@ class ValidationResult
     protected $messages;
 
     /**
+     * @var array
+     */
+    protected $values;
+
+    /**
      * Construct the validation result.
      *
-     * @param bool $result
+     * @param bool $isValid
      * @param array $messages
+     * @param array $values
      */
-    public function __construct($result, array $messages)
+    public function __construct($isValid, array $messages, array $values)
     {
-        $this->result = $result;
+        $this->isValid = $isValid;
         $this->messages = $messages;
+        $this->values = $values;
     }
 
     /**
@@ -45,7 +51,17 @@ class ValidationResult
      */
     public function isValid()
     {
-        return $this->result;
+        return $this->isValid;
+    }
+
+    /**
+     * Returns whether or not the validator has validated the values.
+     *
+     * @return bool
+     */
+    public function isNotValid()
+    {
+        return !$this->isValid;
     }
 
     /**
@@ -56,5 +72,15 @@ class ValidationResult
     public function getMessages()
     {
         return $this->messages;
+    }
+
+    /**
+     * Returns all validated values
+     *
+     * @return array
+     */
+    public function getValues()
+    {
+        return $this->values;
     }
 }

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -96,45 +96,42 @@ class Validator
     }
 
     /**
-     * Validates the values in the $values array and returns the result as a bool.
+     * Validates the values in the $values array and returns a ValidationResult.
      *
      * @param array $values
      * @param string $context
-     * @return bool
+     * @return ValidationResult
      */
     public function validate(array $values, $context = self::DEFAULT_CONTEXT)
     {
-        $valid = true;
+        $isValid = true;
         $messageStack = $this->buildMessageStack($context);
         $this->output = new Container();
         $input = new Container($values);
 
         foreach ($this->chains[$context] as $chain) {
             /** @var Chain $chain */
-            $valid = $chain->validate($messageStack, $input, $this->output) && $valid;
+            $isValid = $chain->validate($messageStack, $input, $this->output) && $isValid;
         }
-        return $valid;
+
+        return new ValidationResult(
+            $isValid,
+            $this->messageStack->getMessages(),
+            $this->getValues()
+        );
     }
 
     /**
+     * Returns all validated values
+     *
      * @return array
      */
-    public function getValues()
+    protected function getValues()
     {
         if (!$this->output instanceof Container) {
             return [];
         }
         return $this->output->getArrayCopy();
-    }
-
-    /**
-     * Returns an array of all validation failures.
-     *
-     * @return array
-     */
-    public function getMessages()
-    {
-        return $this->messageStack->getMessages();
     }
 
     /**

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -117,21 +117,8 @@ class Validator
         return new ValidationResult(
             $isValid,
             $this->messageStack->getMessages(),
-            $this->getValues()
+            $this->output->getArrayCopy()
         );
-    }
-
-    /**
-     * Returns all validated values
-     *
-     * @return array
-     */
-    protected function getValues()
-    {
-        if (!$this->output instanceof Container) {
-            return [];
-        }
-        return $this->output->getArrayCopy();
     }
 
     /**

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -27,8 +27,8 @@ class ContextTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->validator->validate(['first_name' => 'berry'], 'insert');
 
-        $this->assertTrue($result);
-        $this->assertEquals([], $this->validator->getMessages());
+        $this->assertTrue($result->isValid());
+        $this->assertEquals([], $result->getMessages());
     }
 
     public function testCanHaveIndependentMessages()
@@ -49,13 +49,13 @@ class ContextTest extends \PHPUnit_Framework_TestCase
             ]
         ]);
 
-        $this->validator->validate(['first_name' => 'Rick'], 'insert');
+        $result = $this->validator->validate(['first_name' => 'Rick'], 'insert');
         $expected = [
             'first_name' => [
                 Rule\Length::TOO_SHORT => 'This is from inside the context.'
             ]
         ];
-        $this->assertEquals($expected, $this->validator->getMessages());
+        $this->assertEquals($expected, $result->getMessages());
     }
 
     public function testMessagesWillBeInheritedFromDefaultContext()
@@ -70,7 +70,7 @@ class ContextTest extends \PHPUnit_Framework_TestCase
             ]
         ]);
 
-        $this->validator->validate(['first_name' => 'Rick'], 'insert');
+        $result = $this->validator->validate(['first_name' => 'Rick'], 'insert');
 
         $expected = [
             'first_name' => [
@@ -78,7 +78,7 @@ class ContextTest extends \PHPUnit_Framework_TestCase
             ]
         ];
 
-        $this->assertEquals($expected, $this->validator->getMessages());
+        $this->assertEquals($expected, $result->getMessages());
     }
 
     public function testContextCanCopyRulesFromOtherContext()
@@ -97,14 +97,15 @@ class ContextTest extends \PHPUnit_Framework_TestCase
             $context->copyContext('insert');
         });
 
-        $this->assertFalse($this->validator->validate(['first_name' => 'Rick'], 'update'));
+        $result = $this->validator->validate(['first_name' => 'Rick'], 'update');
+        $this->assertFalse($result->isValid());
 
         $expected = [
             'first_name' => [
                 Rule\Length::TOO_SHORT => 'From inside the "insert" context.'
             ]
         ];
-        $this->assertEquals($expected, $this->validator->getMessages());
+        $this->assertEquals($expected, $result->getMessages());
     }
 
     public function testContextCopyCanAlterChains()
@@ -124,7 +125,8 @@ class ContextTest extends \PHPUnit_Framework_TestCase
             });
         });
 
-        $this->assertTrue($this->validator->validate([], 'update'));
+        $result = $this->validator->validate([], 'update');
+        $this->assertTrue($result->isValid());
     }
 
     public function testContextCopyClonesButDoesNotOverwrite()
@@ -144,6 +146,7 @@ class ContextTest extends \PHPUnit_Framework_TestCase
             });
         });
 
-        $this->assertFalse($this->validator->validate([], 'insert'));
+        $result = $this->validator->validate([], 'insert');
+        $this->assertFalse($result->isValid());
     }
 }

--- a/tests/Rule/AlnumTest.php
+++ b/tests/Rule/AlnumTest.php
@@ -25,8 +25,8 @@ class AlnumTest extends \PHPUnit_Framework_TestCase
         $this->validator->required('first_name')->alnum();
         $result = $this->validator->validate(['first_name' => $value]);
 
-        $this->assertTrue($result);
-        $this->assertEquals([], $this->validator->getMessages());
+        $this->assertTrue($result->isValid());
+        $this->assertEquals([], $result->getMessages());
     }
 
     /**
@@ -38,8 +38,8 @@ class AlnumTest extends \PHPUnit_Framework_TestCase
         $this->validator->required('first_name')->alnum(true);
         $result = $this->validator->validate(['first_name' => $value]);
 
-        $this->assertTrue($result);
-        $this->assertEquals([], $this->validator->getMessages());
+        $this->assertTrue($result->isValid());
+        $this->assertEquals([], $result->getMessages());
     }
 
     /**
@@ -51,8 +51,8 @@ class AlnumTest extends \PHPUnit_Framework_TestCase
         $this->validator->required('first_name')->alnum(true);
         $result = $this->validator->validate(['first_name' => $value]);
 
-        $this->assertTrue($result);
-        $this->assertEquals([], $this->validator->getMessages());
+        $this->assertTrue($result->isValid());
+        $this->assertEquals([], $result->getMessages());
     }
 
     /**
@@ -66,8 +66,8 @@ class AlnumTest extends \PHPUnit_Framework_TestCase
 
         $expected = ['first_name' => [$errorReason => $this->getMessage($errorReason)]];
 
-        $this->assertFalse($result);
-        $this->assertEquals($expected, $this->validator->getMessages());
+        $this->assertFalse($result->isValid());
+        $this->assertEquals($expected, $result->getMessages());
     }
 
     public function getAlphanumericWithoutSpaces()

--- a/tests/Rule/AlphaTest.php
+++ b/tests/Rule/AlphaTest.php
@@ -25,8 +25,8 @@ class AlphaTest extends \PHPUnit_Framework_TestCase
         $this->validator->required('first_name')->alpha();
         $result = $this->validator->validate(['first_name' => $value]);
 
-        $this->assertTrue($result);
-        $this->assertEquals([], $this->validator->getMessages());
+        $this->assertTrue($result->isValid());
+        $this->assertEquals([], $result->getMessages());
     }
 
     /**
@@ -38,8 +38,8 @@ class AlphaTest extends \PHPUnit_Framework_TestCase
         $this->validator->required('first_name')->alpha(true);
         $result = $this->validator->validate(['first_name' => $value]);
 
-        $this->assertTrue($result);
-        $this->assertEquals([], $this->validator->getMessages());
+        $this->assertTrue($result->isValid());
+        $this->assertEquals([], $result->getMessages());
     }
 
     /**
@@ -51,8 +51,8 @@ class AlphaTest extends \PHPUnit_Framework_TestCase
         $this->validator->required('first_name')->alpha(true);
         $result = $this->validator->validate(['first_name' => $value]);
 
-        $this->assertTrue($result);
-        $this->assertEquals([], $this->validator->getMessages());
+        $this->assertTrue($result->isValid());
+        $this->assertEquals([], $result->getMessages());
     }
 
     /**
@@ -66,8 +66,8 @@ class AlphaTest extends \PHPUnit_Framework_TestCase
 
         $expected = ['first_name' => [$errorReason => $this->getMessage($errorReason)]];
 
-        $this->assertFalse($result);
-        $this->assertEquals($expected, $this->validator->getMessages());
+        $this->assertFalse($result->isValid());
+        $this->assertEquals($expected, $result->getMessages());
     }
 
     public function getAlphaWithoutSpaces()

--- a/tests/Rule/BetweenTest.php
+++ b/tests/Rule/BetweenTest.php
@@ -21,8 +21,8 @@ class BetweenTest extends \PHPUnit_Framework_TestCase
         $this->validator->required('number')->between(1, 10);
         $result = $this->validator->validate(['number' => 5]);
 
-        $this->assertTrue($result);
-        $this->assertEquals([], $this->validator->getMessages());
+        $this->assertTrue($result->isValid());
+        $this->assertEquals([], $result->getMessages());
     }
 
     public function testValidatesInclusiveByDefault()
@@ -30,8 +30,8 @@ class BetweenTest extends \PHPUnit_Framework_TestCase
         $this->validator->required('number')->between(1, 10);
         $result = $this->validator->validate(['number' => 1]);
 
-        $this->assertTrue($result);
-        $this->assertEquals([], $this->validator->getMessages());
+        $this->assertTrue($result->isValid());
+        $this->assertEquals([], $result->getMessages());
     }
 
     public function testReturnsFalseForValuesNotBetweenMinAndMaxLowerError()
@@ -44,8 +44,8 @@ class BetweenTest extends \PHPUnit_Framework_TestCase
                 Between::TOO_SMALL => $this->getMessage(Between::TOO_SMALL)
             ]
         ];
-        $this->assertFalse($result);
-        $this->assertEquals($expected, $this->validator->getMessages());
+        $this->assertFalse($result->isValid());
+        $this->assertEquals($expected, $result->getMessages());
     }
 
     public function testReturnsFalseForValuesNotBetweenMinAndMaxUpperError()
@@ -58,8 +58,8 @@ class BetweenTest extends \PHPUnit_Framework_TestCase
                 Between::TOO_BIG => $this->getMessage(Between::TOO_BIG)
             ]
         ];
-        $this->assertFalse($result);
-        $this->assertEquals($expected, $this->validator->getMessages());
+        $this->assertFalse($result->isValid());
+        $this->assertEquals($expected, $result->getMessages());
     }
 
     public function getMessage($reason)

--- a/tests/Rule/BoolTest.php
+++ b/tests/Rule/BoolTest.php
@@ -25,12 +25,12 @@ class BoolTest extends \PHPUnit_Framework_TestCase
     {
         $this->validator->required('active')->bool();
         $result = $this->validator->validate(['active' => $value]);
-        $this->assertEquals($expected, $result);
+        $this->assertEquals($expected, $result->isValid());
 
         if ($expected === false) {
             $this->assertEquals(
                 $this->getMessage(Bool::NOT_BOOL),
-                $this->validator->getMessages()['active'][Bool::NOT_BOOL]
+                $result->getMessages()['active'][Bool::NOT_BOOL]
             );
         }
     }

--- a/tests/Rule/CallbackTest.php
+++ b/tests/Rule/CallbackTest.php
@@ -24,7 +24,7 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
         });
 
         $result = $this->validator->validate(['first_name' => 'berry']);
-        $this->assertTrue($result);
+        $this->assertTrue($result->isValid());
     }
 
     public function testReturnsFalseAndLogsErrorWhenCallbackReturnsFalse()
@@ -34,7 +34,7 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
         });
 
         $result = $this->validator->validate(['first_name' => 'berry']);
-        $this->assertFalse($result);
+        $this->assertFalse($result->isValid());
 
         $expected = [
             'first_name' => [
@@ -42,7 +42,7 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
             ]
         ];
 
-        $this->assertEquals($expected, $this->validator->getMessages());
+        $this->assertEquals($expected, $result->getMessages());
     }
 
     public function testCanLogDifferentErrorMessageByThrowingException()
@@ -58,7 +58,7 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
         });
 
         $result = $this->validator->validate(['first_name' => 'bill']);
-        $this->assertFalse($result);
+        $this->assertFalse($result->isValid());
 
         $expected = [
             'first_name' => [
@@ -66,7 +66,7 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
             ]
         ];
 
-        $this->assertEquals($expected, $this->validator->getMessages());
+        $this->assertEquals($expected, $result->getMessages());
     }
 
     public function testCanReadTheContextOfValidation()
@@ -76,7 +76,7 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
         });
 
         $result = $this->validator->validate(['first_name' => 'Berry', 'last_name' => 'Langerak']);
-        $this->assertTrue($result);
+        $this->assertTrue($result->isValid());
     }
 
     public function getMessage($reason)

--- a/tests/Rule/DatetimeTest.php
+++ b/tests/Rule/DatetimeTest.php
@@ -21,26 +21,32 @@ class DatetimeTest extends \PHPUnit_Framework_TestCase
         $this->validator->required('time')->datetime('H:i');
         $result = $this->validator->validate(['time' => '18:00']);
 
-        $this->assertEquals([], $this->validator->getMessages());
-        $this->assertTrue($result);
+        $this->assertEquals([], $result->getMessages());
+        $this->assertTrue($result->isValid());
 
         $result = $this->validator->validate(['time' => (new DateTime())->format('Y-m-d H:i:s')]);
 
-        $this->assertFalse($result);
+        $this->assertFalse($result->isValid());
         $expected = [
             'time' => [
                 \Particle\Validator\Rule\Datetime::INVALID_VALUE => 'time must be a valid date'
             ]
         ];
-        $this->assertEquals($expected, $this->validator->getMessages());
+        $this->assertEquals($expected, $result->getMessages());
     }
 
     public function testWillTakeManyFormatsIfNoFormatPassed()
     {
         $this->validator->required('time')->datetime();
-        $this->assertTrue($this->validator->validate(['time' => '18:00']));
-        $this->assertTrue($this->validator->validate(['time' => '2015-03-29 16:11:09']));
-        $this->assertTrue($this->validator->validate(['time' => '29-03-2015 16:11:09']));
+
+        $result = $this->validator->validate(['time' => '18:00']);
+        $this->assertTrue($result->isValid());
+
+        $result = $this->validator->validate(['time' => '2015-03-29 16:11:09']);
+        $this->assertTrue($result->isValid());
+
+        $this->validator->validate(['time' => '29-03-2015 16:11:09']);
+        $this->assertTrue($result->isValid());
     }
 
     public function testReturnsFalseOnUnparsableDate()
@@ -48,13 +54,13 @@ class DatetimeTest extends \PHPUnit_Framework_TestCase
         $this->validator->required('time')->datetime();
         $result = $this->validator->validate(['time' => 'This is not a date. Not even close.']);
 
-        $this->assertFalse($result);
+        $this->assertFalse($result->isValid());
         $expected = [
             'time' => [
                 \Particle\Validator\Rule\Datetime::INVALID_VALUE => 'time must be a valid date'
             ]
         ];
-        $this->assertEquals($expected, $this->validator->getMessages());
+        $this->assertEquals($expected, $result->getMessages());
     }
 
 
@@ -68,14 +74,14 @@ class DatetimeTest extends \PHPUnit_Framework_TestCase
             'date' => '12111978',
         ]);
 
-        $this->assertFalse($result);
+        $this->assertFalse($result->isValid());
         $expected = [
             'date' => [
                 \Particle\Validator\Rule\DateTime::INVALID_VALUE => 'date must be a valid date'
             ]
         ];
 
-        $this->assertEquals($expected, $this->validator->getMessages());
+        $this->assertEquals($expected, $result->getMessages());
     }
 
     public function getMessage($reason)

--- a/tests/Rule/DigitsTest.php
+++ b/tests/Rule/DigitsTest.php
@@ -19,7 +19,8 @@ class DigitsTest extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueOnOnlyDigitCharacters()
     {
         $this->validator->required('digits')->digits();
-        $this->assertTrue($this->validator->validate(['digits' => '123456789']));
+        $result = $this->validator->validate(['digits' => '123456789']);
+        $this->assertTrue($result->isValid());
     }
 
     /**
@@ -29,14 +30,15 @@ class DigitsTest extends \PHPUnit_Framework_TestCase
     public function testReturnsFalseOnNonDigitCharacters($value)
     {
         $this->validator->required('digits')->digits();
-        $this->assertFalse($this->validator->validate(['digits' => $value]));
+        $result = $this->validator->validate(['digits' => $value]);
+        $this->assertFalse($result->isValid());
 
         $expected = [
             'digits' => [
                 Digits::NOT_DIGITS => $this->getMessage(Digits::NOT_DIGITS)
             ]
         ];
-        $this->assertEquals($expected, $this->validator->getMessages());
+        $this->assertEquals($expected, $result->getMessages());
     }
 
     public function getNotOnlyDigitValues()

--- a/tests/Rule/EmailTest.php
+++ b/tests/Rule/EmailTest.php
@@ -24,23 +24,25 @@ class EmailTest extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueOnValidEmailaddresses($value)
     {
         $this->validator->required('email')->email();
-        $this->assertTrue($this->validator->validate(['email' => $value]));
+        $result = $this->validator->validate(['email' => $value]);
+        $this->assertTrue($result->isValid());
     }
 
     /**
      * @dataProvider getInvalidAddresses
      * @param string $value
      */
-    public function testReturnsFalseOnInvalidEmailaddresses($value)
+    public function testReturnsFalseOnInvalidEmailAddresses($value)
     {
         $this->validator->required('email')->email();
-        $this->assertFalse($this->validator->validate(['email' => $value]));
+        $result = $this->validator->validate(['email' => $value]);
+        $this->assertFalse($result->isValid());
         $expected = [
             'email' => [
                 Email::INVALID_FORMAT => 'email must be a valid email address'
             ]
         ];
-        $this->assertEquals($expected, $this->validator->getMessages());
+        $this->assertEquals($expected, $result->getMessages());
     }
 
     /**

--- a/tests/Rule/EqualTest.php
+++ b/tests/Rule/EqualTest.php
@@ -19,20 +19,25 @@ class EqualTest extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueOnEqualValue()
     {
         $this->validator->required('first_name')->equals('berry');
-        $this->assertTrue($this->validator->validate(['first_name' => 'berry']));
+        $result = $this->validator->validate(['first_name' => 'berry']);
+        $this->assertTrue($result->isValid());
     }
 
     public function testReturnsFalseOnNonEqualValue()
     {
         $this->validator->required('first_name')->equals(0);
-        $this->assertFalse($this->validator->validate(['first_name' => '0'])); // strict typing all the way!
-        $this->assertFalse($this->validator->validate(['first_name' => 'No cigar, and not even close.']));
+
+        $result = $this->validator->validate(['first_name' => '0']); // strict typing all the way!
+        $this->assertFalse($result->isValid());
+
+        $result = $this->validator->validate(['first_name' => 'No cigar, and not even close.']);
+        $this->assertFalse($result->isValid());
 
         $expected = [
             'first_name' => [
                 Equal::NOT_EQUAL => 'first name must be equal to "0"'
             ]
         ];
-        $this->assertEquals($expected, $this->validator->getMessages());
+        $this->assertEquals($expected, $result->getMessages());
     }
 }

--- a/tests/Rule/InArrayTest.php
+++ b/tests/Rule/InArrayTest.php
@@ -19,13 +19,15 @@ class InArrayTest extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueIfValueIsInArrayWithStrictChecking()
     {
         $this->validator->required('group')->inArray(['foo', 'bar']);
-        $this->assertTrue($this->validator->validate(['group' => 'foo']));
+        $result = $this->validator->validate(['group' => 'foo']);
+        $this->assertTrue($result->isValid());
     }
 
     public function testReturnsFalseIfValueIsNotInArrayWithStrictChecking()
     {
         $this->validator->required('group')->inArray([0]);
-        $this->assertFalse($this->validator->validate(['group' => '0']));
+        $result = $this->validator->validate(['group' => '0']);
+        $this->assertFalse($result->isValid());
 
         $expected = [
             'group' => [
@@ -33,7 +35,7 @@ class InArrayTest extends \PHPUnit_Framework_TestCase
             ]
         ];
 
-        $this->assertEquals($expected, $this->validator->getMessages());
+        $this->assertEquals($expected, $result->getMessages());
     }
 
     public function testCanUseTheValuesInErrorMessage()
@@ -45,20 +47,21 @@ class InArrayTest extends \PHPUnit_Framework_TestCase
                 InArray::NOT_IN_ARRAY => '{{ name }} must be one of {{ values }}'
             ]
         ]);
-        $this->assertFalse($this->validator->validate(['group' => 'none']));
+        $result = $this->validator->validate(['group' => 'none']);
+        $this->assertFalse($result->isValid());
 
         $expected = [
             'group' => [
                 InArray::NOT_IN_ARRAY => 'group must be one of "users", "admins"'
             ]
         ];
-
-        $this->assertEquals($expected, $this->validator->getMessages());
+        $this->assertEquals($expected, $result->getMessages());
     }
 
     public function testReturnsTrueIfValueIsSortOfInArrayWithoutStrictChecking()
     {
         $this->validator->required('group')->inArray([0], false);
-        $this->assertTrue($this->validator->validate(['group' => '0']));
+        $result = $this->validator->validate(['group' => '0']);
+        $this->assertTrue($result->isValid());
     }
 }

--- a/tests/Rule/IntegerTest.php
+++ b/tests/Rule/IntegerTest.php
@@ -23,7 +23,8 @@ class IntegerTest extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueOnValidInteger($value)
     {
         $this->validator->required('integer')->integer();
-        $this->assertTrue($this->validator->validate(['integer' => $value]));
+        $result = $this->validator->validate(['integer' => $value]);
+        $this->assertTrue($result->isValid());
     }
 
     /**
@@ -33,14 +34,15 @@ class IntegerTest extends \PHPUnit_Framework_TestCase
     public function testReturnsFalseOnInvalidIntegers($value)
     {
         $this->validator->required('integer')->integer();
-        $this->assertFalse($this->validator->validate(['integer' => $value]));
+        $result = $this->validator->validate(['integer' => $value]);
+        $this->assertFalse($result->isValid());
 
         $expected = [
             'integer' => [
                 Integer::NOT_AN_INTEGER => $this->getMessage(Integer::NOT_AN_INTEGER)
             ]
         ];
-        $this->assertEquals($expected, $this->validator->getMessages());
+        $this->assertEquals($expected, $result->getMessages());
     }
 
     public function getValidIntegerValues()

--- a/tests/Rule/LengthBetweenTest.php
+++ b/tests/Rule/LengthBetweenTest.php
@@ -19,16 +19,21 @@ class LengthBetweenTest extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueIfLengthIsExactlyMinOrMax()
     {
         $this->validator->required('first_name')->lengthBetween(2, 7);
-        $this->assertTrue($this->validator->validate(['first_name' => 'ad']));
-        $this->assertTrue($this->validator->validate(['first_name' => 'Richard']));
-        $this->assertEquals([], $this->validator->getMessages());
+
+        $result = $this->validator->validate(['first_name' => 'ad']);
+        $this->assertTrue($result->isValid());
+
+        $result = $this->validator->validate(['first_name' => 'Richard']);
+        $this->assertTrue($result->isValid());
+        $this->assertEquals([], $result->getMessages());
     }
 
     public function testReturnsTrueIfMaxIsNull()
     {
         $this->validator->required('password')->lengthBetween(2, null);
-        $this->assertTrue($this->validator->validate(['password' => str_repeat('foo', 100)]));
-        $this->assertEquals([], $this->validator->getMessages());
+        $result = $this->validator->validate(['password' => str_repeat('foo', 100)]);
+        $this->assertTrue($result->isValid());
+        $this->assertEquals([], $result->getMessages());
     }
 
     public function testReturnsFalseIfInvalid()
@@ -36,24 +41,24 @@ class LengthBetweenTest extends \PHPUnit_Framework_TestCase
         $this->validator->required('first_name')->lengthBetween(3, 6);
         $result = $this->validator->validate(['first_name' => 'ad']);
 
-        $this->assertFalse($result);
+        $this->assertFalse($result->isValid());
 
         $expected = [
             'first_name' => [
                 LengthBetween::TOO_SHORT => $this->getMessage(LengthBetween::TOO_SHORT)
             ]
         ];
-        $this->assertEquals($expected, $this->validator->getMessages());
+        $this->assertEquals($expected, $result->getMessages());
 
         $result = $this->validator->validate(['first_name' => 'Richard']);
 
-        $this->assertFalse($result);
+        $this->assertFalse($result->isValid());
         $expected = [
             'first_name' => [
                 LengthBetween::TOO_LONG => $this->getMessage(LengthBetween::TOO_LONG)
             ]
         ];
-        $this->assertEquals($expected, $this->validator->getMessages());
+        $this->assertEquals($expected, $result->getMessages());
     }
 
     public function getMessage($reason)

--- a/tests/Rule/LengthTest.php
+++ b/tests/Rule/LengthTest.php
@@ -27,8 +27,8 @@ class LengthTest extends \PHPUnit_Framework_TestCase
         $result = $this->validator->validate(['first_name' => $value]);
 
         $expected = ['first_name' => [$error => $this->getMessage($error)]];
-        $this->assertFalse($result);
-        $this->assertEquals($expected, $this->validator->getMessages());
+        $this->assertFalse($result->isValid());
+        $this->assertEquals($expected, $result->getMessages());
     }
 
     /**
@@ -39,8 +39,7 @@ class LengthTest extends \PHPUnit_Framework_TestCase
     {
         $this->validator->required('first_name')->length(5);
         $result = $this->validator->validate(['first_name' => $value]);
-
-        $this->assertTrue($result);
+        $this->assertTrue($result->isValid());
     }
 
     public function getInvalidValues()

--- a/tests/Rule/NotEmptyTest.php
+++ b/tests/Rule/NotEmptyTest.php
@@ -25,7 +25,7 @@ class NotEmptyTest extends \PHPUnit_Framework_TestCase
         $this->validator->optional('foo', 'foo', false);
         $result = $this->validator->validate(['foo' => $value]);
 
-        $this->assertTrue($result);
+        $this->assertTrue($result->isValid());
     }
 
     /**
@@ -36,8 +36,8 @@ class NotEmptyTest extends \PHPUnit_Framework_TestCase
         $this->validator->optional('foo', 'foo', false);
         $result = $this->validator->validate(['foo' => $value]);
 
-        $this->assertFalse($result);
-        $this->assertArrayHasKey(NotEmpty::EMPTY_VALUE, $this->validator->getMessages()['foo']);
+        $this->assertFalse($result->isValid());
+        $this->assertArrayHasKey(NotEmpty::EMPTY_VALUE, $result->getMessages()['foo']);
     }
 
     public function testBreaksChainOnAllowedEmptyValues()
@@ -48,8 +48,8 @@ class NotEmptyTest extends \PHPUnit_Framework_TestCase
             'foo' => null,
         ]);
 
-        $this->assertTrue($result);
-        $this->assertEquals([], $this->validator->getMessages());
+        $this->assertTrue($result->isValid());
+        $this->assertEquals([], $result->getMessages());
     }
 
     public function testAllowEmptyCanBeConditional()
@@ -60,19 +60,19 @@ class NotEmptyTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->validator->validate(['foo' => 'bar', 'first_name' => '']);
 
-        $this->assertFalse($result);
+        $this->assertFalse($result->isValid());
         $this->assertEquals(
             [
                 'first_name' => [
                     NotEmpty::EMPTY_VALUE => 'first name must not be empty'
                 ]
             ],
-            $this->validator->getMessages()
+            $result->getMessages()
         );
 
         $result = $this->validator->validate(['foo' => 'not bar!', 'first_name' => '']);
-        $this->assertTrue($result);
-        $this->assertEquals([], $this->validator->getMessages());
+        $this->assertTrue($result->isValid());
+        $this->assertEquals([], $result->getMessages());
     }
 
 

--- a/tests/Rule/RegexTest.php
+++ b/tests/Rule/RegexTest.php
@@ -19,20 +19,21 @@ class RegexTest extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueWhenMatchesRegex()
     {
         $this->validator->required('first_name')->regex('/^berry$/i');
-        $this->assertTrue($this->validator->validate(['first_name' => 'Berry']));
-        $this->assertEquals([], $this->validator->getMessages());
+        $result = $this->validator->validate(['first_name' => 'Berry']);
+        $this->assertTrue($result->isValid());
+        $this->assertEquals([], $result->getMessages());
     }
 
     public function testReturnsFalseOnNoMatch()
     {
         $this->validator->required('first_name')->regex('~this wont match~');
-        $this->assertFalse($this->validator->validate(['first_name' => 'Berry']));
+        $result = $this->validator->validate(['first_name' => 'Berry']);
+        $this->assertFalse($result->isValid());
         $expected = [
             'first_name' => [
                 Regex::NO_MATCH => 'first name is invalid'
             ]
         ];
-
-        $this->assertEquals($expected, $this->validator->getMessages());
+        $this->assertEquals($expected, $result->getMessages());
     }
 }

--- a/tests/Rule/RequiredTest.php
+++ b/tests/Rule/RequiredTest.php
@@ -23,7 +23,7 @@ class RequiredTest extends \PHPUnit_Framework_TestCase
         $result = $this->validator->validate([
         ]);
 
-        $this->assertFalse($result);
+        $this->assertFalse($result->isValid());
     }
 
     public function testReturnsTrueOnSetRequiredValues()
@@ -32,7 +32,7 @@ class RequiredTest extends \PHPUnit_Framework_TestCase
         $result = $this->validator->validate([
             'foo' => 'bar'
         ]);
-        $this->assertTrue($result);
+        $this->assertTrue($result->isValid());
     }
 
     public function testReturnsTrueOnAnyValue()
@@ -42,11 +42,11 @@ class RequiredTest extends \PHPUnit_Framework_TestCase
         $this->validator->required('foo');
 
         foreach ($values as $value) {
-            $this->validator->validate(['foo' => $value]);
+            $result = $this->validator->validate(['foo' => $value]);
 
             $this->assertArrayNotHasKey(
                 Required::NON_EXISTENT_KEY,
-                $this->validator->getMessages()
+                $result->getMessages()
             );
         }
     }
@@ -59,18 +59,18 @@ class RequiredTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->validator->validate(['foo' => 'bar']);
 
-        $this->assertFalse($result);
+        $this->assertFalse($result->isValid());
         $this->assertEquals(
             [
                 'first_name' => [
                     Required::NON_EXISTENT_KEY => 'first_name must be provided, but does not exist',
                 ]
             ],
-            $this->validator->getMessages()
+            $result->getMessages()
         );
 
         $result = $this->validator->validate(['foo' => 'not bar!']);
-        $this->assertTrue($result);
-        $this->assertEquals([], $this->validator->getMessages());
+        $this->assertTrue($result->isValid());
+        $this->assertEquals([], $result->getMessages());
     }
 }

--- a/tests/Rule/UrlTest.php
+++ b/tests/Rule/UrlTest.php
@@ -23,8 +23,9 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueOnValidUrls($value)
     {
         $this->validator->required('url')->url();
-        $this->assertTrue($this->validator->validate(['url' => $value]));
-        $this->assertEquals([], $this->validator->getMessages());
+        $result = $this->validator->validate(['url' => $value]);
+        $this->assertTrue($result->isValid());
+        $this->assertEquals([], $result->getMessages());
     }
 
     /**
@@ -35,13 +36,14 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     public function testReturnsFalseOnInvalidUrls($value, $error)
     {
         $this->validator->required('url')->url();
-        $this->assertFalse($this->validator->validate(['url' => $value]));
+        $result = $this->validator->validate(['url' => $value]);
+        $this->assertFalse($result->isValid());
         $expected = [
             'url' => [
-                Url::INVALID_URL => 'url must be a valid URL'
+                $error => 'url must be a valid URL'
             ]
         ];
-        $this->assertEquals($expected, $this->validator->getMessages());
+        $this->assertEquals($expected, $result->getMessages());
     }
 
     public function getValidUrls()

--- a/tests/Rule/UuidTest.php
+++ b/tests/Rule/UuidTest.php
@@ -19,14 +19,16 @@ class UuidV4Test extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueWhenMatchesUuidV4()
     {
         $this->validator->required('guid')->uuid();
-        $this->assertTrue($this->validator->validate(['guid' => '44c0ffee-988a-49dc-0bad-a55c0de2d1e4']));
-        $this->assertEquals([], $this->validator->getMessages());
+        $result = $this->validator->validate(['guid' => '44c0ffee-988a-49dc-0bad-a55c0de2d1e4']);
+        $this->assertTrue($result->isValid());
+        $this->assertEquals([], $result->getMessages());
     }
 
     public function testReturnsFalseOnNoMatch()
     {
         $this->validator->required('guid')->uuid();
-        $this->assertFalse($this->validator->validate(['guid' => 'xxc0ffee-988a-49dc-0bad-a55c0de2d1e4']));
+        $result = $this->validator->validate(['guid' => 'xxc0ffee-988a-49dc-0bad-a55c0de2d1e4']);
+        $this->assertFalse($result->isValid());
 
         $expected = [
             'guid' => [
@@ -34,7 +36,7 @@ class UuidV4Test extends \PHPUnit_Framework_TestCase
             ]
         ];
 
-        $this->assertEquals($expected, $this->validator->getMessages());
+        $this->assertEquals($expected, $result->getMessages());
     }
 
     public function testThrowsExceptionOnUnknownVersion()

--- a/tests/ValidationResultTest.php
+++ b/tests/ValidationResultTest.php
@@ -19,6 +19,7 @@ class ValidationResultTest extends \PHPUnit_Framework_TestCase
         ];
 
         $result = new ValidationResult(false, $messages, $values);
+
         $this->assertFalse($result->isValid());
         $this->assertTrue($result->isNotValid());
         $this->assertEquals($messages, $result->getMessages());

--- a/tests/ValidationResultTest.php
+++ b/tests/ValidationResultTest.php
@@ -8,15 +8,20 @@ class ValidationResultTest extends \PHPUnit_Framework_TestCase
 {
     public function testReturnsResultAndMessages()
     {
-        // lamest test ever, but then, the ValidationResult is only for convenience.
+        $values = [
+            'first_name' => 'test',
+        ];
+
         $messages = [
             'first_name' => [
                 Alpha::NOT_ALPHA => 'first name may only consist out of alphabetical characters'
             ]
         ];
 
-        $result = new ValidationResult(false, $messages);
+        $result = new ValidationResult(false, $messages, $values);
         $this->assertFalse($result->isValid());
+        $this->assertTrue($result->isNotValid());
         $this->assertEquals($messages, $result->getMessages());
+        $this->assertEquals($values, $result->getValues());
     }
 }


### PR DESCRIPTION
### What

To keep the validation API result clean and make sure you have everything you want after validation in a neat package, we moved the validation result to... ValidationResult! This is now returned by the `validate()` function, and allows you to do the following functions:

* `->isValid() : bool`
* `->isNotValid() : bool`
* `->getMessages() : array` an array with the validation messages
* `->getValues() : array` an array with the validated fields

### How to test

1. See that `validate()` now returns a ValidatonResult
1. See that you can call the 4 functions stated above from the ValidatonResult
1. See that all tests pass with the new `ValidatonResult->isValid()` functionality
1. See that the documentation is updated, and ValidationResult is used everywhere.
1. See that the code coverage and quality is still 100%

### ToDo

* [x] Make sure the coverage and quality is still 100%
* [x] Update the documentation
* [x] Add better usage example

### Note

Version `v2.0.0` should be released after this is merged, because existing usage of particle/validator ~1 will break once updated.