### PR TITLE
Bugfix/59 fix datetime bug from 1.0

### DIFF
--- a/src/Rule/Datetime.php
+++ b/src/Rule/Datetime.php
@@ -70,15 +70,28 @@ class Datetime extends Rule
     protected function datetime($value, $format = null)
     {
         if ($format !== null) {
-            $dt = date_create_from_format($format, $value);
-            if ($dt instanceof \DateTime && $dt->getLastErrors()['warning_count'] === 0) {
-                // ensures that the format structure is respected.
-                if ($dt->format($format) === $value) {
-                    return $dt;
-                }
+            $dateTime = date_create_from_format($format, $value);
+            if ($dateTime instanceof \DateTime
+                && $dateTime->getLastErrors()['warning_count'] === 0
+                && $this->isFormatRespected($format, $dateTime, $value)
+            ) {
+                return $dateTime;
             }
             return false;
         }
         return @date_create($value);
+    }
+
+    /**
+     * checks if the value respects the format passed to the rule.
+     *
+     * @param string $format the format passed to DateTime
+     * @param \DateTime $dateTime
+     * @param $value the value to be checked
+     * @return bool
+     */
+    protected function isFormatRespected($format, \DateTime $dateTime, $value)
+    {
+        return $dateTime->format($format) === $value;
     }
 }

--- a/src/Rule/Datetime.php
+++ b/src/Rule/Datetime.php
@@ -72,7 +72,10 @@ class Datetime extends Rule
         if ($format !== null) {
             $dt = date_create_from_format($format, $value);
             if ($dt instanceof \DateTime && $dt->getLastErrors()['warning_count'] === 0) {
-                return $dt;
+                // ensures that the format structure is respected.
+                if ($dt->format($format) === $value) {
+                    return $dt;
+                }
             }
             return false;
         }

--- a/src/Rule/Datetime.php
+++ b/src/Rule/Datetime.php
@@ -83,10 +83,10 @@ class Datetime extends Rule
     /**
      * Checks if $dateTime is a valid date-time object, and if the formatted date is the same as the value passed.
      *
-     * @param \DateTime|null $dateTime
+     * @param \DateTime $dateTime
      * @param string $format
      * @param mixed $value
-     * @return bool
+     * @return \DateTime|false
      */
     protected function checkDate($dateTime, $format, $value)
     {

--- a/src/Rule/Datetime.php
+++ b/src/Rule/Datetime.php
@@ -70,28 +70,24 @@ class Datetime extends Rule
     protected function datetime($value, $format = null)
     {
         if ($format !== null) {
-            $dateTime = date_create_from_format($format, $value);
-            if ($dateTime instanceof \DateTime
-                && $dateTime->getLastErrors()['warning_count'] === 0
-                && $this->isFormatRespected($format, $dateTime, $value)
-            ) {
-                return $dateTime;
-            }
-            return false;
+            return $this->checkDate(date_create_from_format($format, $value), $format, $value);
         }
         return @date_create($value);
     }
 
     /**
-     * checks if the value respects the format passed to the rule.
+     * Checks if $dateTime is a valid date-time object, and if the formatted date is the same as the value passed.
      *
-     * @param string $format the format passed to DateTime
-     * @param \DateTime $dateTime
-     * @param $value the value to be checked
+     * @param \DateTime|null $dateTime
+     * @param string $format
+     * @param mixed $value
      * @return bool
      */
-    protected function isFormatRespected($format, \DateTime $dateTime, $value)
+    protected function checkDate($dateTime, $format, $value)
     {
-        return $dateTime->format($format) === $value;
+        if ($dateTime instanceof \DateTime && $dateTime->getLastErrors()['warning_count'] === 0) {
+            return $dateTime->format($format) === $value;
+        }
+        return false;
     }
 }

--- a/src/Rule/Datetime.php
+++ b/src/Rule/Datetime.php
@@ -86,7 +86,9 @@ class Datetime extends Rule
     protected function checkDate($dateTime, $format, $value)
     {
         if ($dateTime instanceof \DateTime && $dateTime->getLastErrors()['warning_count'] === 0) {
-            return $dateTime->format($format) === $value;
+            if ($dateTime->format($format) === $value) {
+                return $dateTime;
+            }
         }
         return false;
     }

--- a/src/Rule/Datetime.php
+++ b/src/Rule/Datetime.php
@@ -70,7 +70,12 @@ class Datetime extends Rule
     protected function datetime($value, $format = null)
     {
         if ($format !== null) {
-            return $this->checkDate(date_create_from_format($format, $value), $format, $value);
+            $dateTime = date_create_from_format($format, $value);
+
+            if ($dateTime instanceof \DateTime) {
+                return $this->checkDate($dateTime, $format, $value);
+            }
+            return false;
         }
         return @date_create($value);
     }
@@ -85,10 +90,8 @@ class Datetime extends Rule
      */
     protected function checkDate($dateTime, $format, $value)
     {
-        if ($dateTime instanceof \DateTime && $dateTime->getLastErrors()['warning_count'] === 0) {
-            if ($dateTime->format($format) === $value) {
-                return $dateTime;
-            }
+        if ($dateTime->getLastErrors()['warning_count'] === 0 && $dateTime->format($format) === $value) {
+            return $dateTime;
         }
         return false;
     }

--- a/tests/Rule/DatetimeTest.php
+++ b/tests/Rule/DatetimeTest.php
@@ -57,7 +57,6 @@ class DatetimeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $this->validator->getMessages());
     }
 
-
     /**
      * @link https://github.com/particle-php/Validator/issues/31
      */
@@ -92,14 +91,14 @@ class DatetimeTest extends \PHPUnit_Framework_TestCase
         );
 
         // should fail because Ymd expects 20151205 instead of 2015125
-        $this->assertFalse($result->isValid());
+        $this->assertFalse($result);
         $expected = [
             'date' => [
                 \Particle\Validator\Rule\DateTime::INVALID_VALUE => 'date must be a valid date'
             ]
         ];
 
-        $this->assertEquals($expected, $result->getMessages());
+        $this->assertEquals($expected, $this->validator->getMessages());
     }
 
     public function getMessage($reason)

--- a/tests/Rule/DatetimeTest.php
+++ b/tests/Rule/DatetimeTest.php
@@ -78,6 +78,30 @@ class DatetimeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $this->validator->getMessages());
     }
 
+
+    /**
+     * @link https://github.com/particle-php/Validator/issues/59
+     */
+    public function testCheckForFormatRespect()
+    {
+        $this->validator->required('date')->datetime('Ymd');
+        $result = $this->validator->validate(
+            [
+                 'date' => '2015125',
+            ]
+        );
+
+        // should fail because Ymd expects 20151205 instead of 2015125
+        $this->assertFalse($result->isValid());
+        $expected = [
+            'date' => [
+                \Particle\Validator\Rule\DateTime::INVALID_VALUE => 'date must be a valid date'
+            ]
+        ];
+
+        $this->assertEquals($expected, $result->getMessages());
+    }
+
     public function getMessage($reason)
     {
         $messages = [


### PR DESCRIPTION
## What?

See PR #60. An issue with the date-time validator was fixed there. That PR was, however, created against master, which means we'd have to create a new version to fix this bug. Also, the complexity increased in Validator\Rule\DateTime. So here's the same PR, with an extra commit, and created against a new "v1.0" branch, so that we can do bug fixes separately from the master branch, which is for ongoing development.

## Test

See the unit test and if they are sufficient.