### PR TITLE
Fix: Add PHP 5.4, 5.5, and 7 to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ matrix:
     - php: 5.6
       env: SCRUTINIZER_REPORT=true
     - php: 7.0
+  allow_failures:
+    - php: 7.0
 
 before_install:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: php
 
-php:
-  - 5.5
+matrix:
+  include:
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+      env: SCRUTINIZER_REPORT=true
+    - php: 7.0
 
 before_install:
   - composer self-update
@@ -16,6 +21,7 @@ script:
   - php vendor/bin/phpunit --coverage-clover=coverage.clover
   - php vendor/bin/phpcs -n --standard=PSR2 --ignore=vendor .
 
-after_script:
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+after_script: >
+  [ "$SCRUTINIZER_REPORT" = true ]
+  && wget https://scrutinizer-ci.com/ocular.phar
+  && php ocular.phar code-coverage:upload --format=php-clover coverage.clover


### PR DESCRIPTION
This PR

* [x] adds PHP 5.4, PHP 5.6 and 7 to the build matrix