### PR TITLE
Fix: Rename Bool to Boolean

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ matrix:
     - php: 5.6
       env: SCRUTINIZER_REPORT=true
     - php: 7.0
-  allow_failures:
-    - php: 7.0
 
 before_install:
   - composer self-update

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -115,7 +115,7 @@ class Chain
      */
     public function bool()
     {
-        return $this->addRule(new Rule\Bool());
+        return $this->addRule(new Rule\Boolean());
     }
 
     /**

--- a/src/Rule/Boolean.php
+++ b/src/Rule/Boolean.php
@@ -15,7 +15,7 @@ use Particle\Validator\Rule;
  *
  * @package Particle\Validator\Rule
  */
-class Bool extends Rule
+class Boolean extends Rule
 {
     /**
      * A constant that will be used when the value is not in the array without strict checking.

--- a/tests/Rule/BooleanTest.php
+++ b/tests/Rule/BooleanTest.php
@@ -1,10 +1,10 @@
 <?php
 namespace Particle\Tests\Rule;
 
-use Particle\Validator\Rule\Bool;
+use Particle\Validator\Rule\Boolean;
 use Particle\Validator\Validator;
 
-class BoolTest extends \PHPUnit_Framework_TestCase
+class BooleanTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Validator
@@ -29,8 +29,8 @@ class BoolTest extends \PHPUnit_Framework_TestCase
 
         if ($expected === false) {
             $this->assertEquals(
-                $this->getMessage(Bool::NOT_BOOL),
-                $result->getMessages()['active'][Bool::NOT_BOOL]
+                $this->getMessage(Boolean::NOT_BOOL),
+                $result->getMessages()['active'][Boolean::NOT_BOOL]
             );
         }
     }
@@ -53,7 +53,7 @@ class BoolTest extends \PHPUnit_Framework_TestCase
     public function getMessage($reason)
     {
         $messages = [
-            Bool::NOT_BOOL => 'active must be either true or false'
+            Boolean::NOT_BOOL => 'active must be either true or false'
         ];
 
         return $messages[$reason];


### PR DESCRIPTION
This PR

* [x] renames `Rule\Bool` to `Rule\Boolean` in order to prepare for PHP7

Follows #71.