### PR TITLE
Fixing small documentation error

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -56,7 +56,7 @@ class GrumpyRule extends Rule
 {
     const WRONG = 'GrumpyRule::WRONG';
     
-    protected $messages = [
+    protected $messageTemplates = [
         self::WRONG => '{{ who }} hates the value of "{{ name }}"',
     ];
     


### PR DESCRIPTION
I fixed a minor issue in the docmentation where in the code snippet for creating a custom Rule the $messages property was used while getMessage (see https://github.com/particle-php/Validator/blob/master/src/Rule.php#L150) uses $messageTemplates.

I noticed this when I was using the snippet as the basis for a custom validator and my validation failed with an empty message ;)