### PR TITLE
Add overwrite message support to the ValidationResult

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,12 +18,6 @@ $validator = new Validator;
 $validator->required('first_name')->lengthBetween(2, 30)->alpha();
 $validator->required('last_name')->lengthBetween(2, 40)->alpha();
 
-$validator->overwriteMessages([
-    'last_name' => [
-        LengthBetween::TOO_LONG => 'Your name is too long.'
-    ]
-]);
-
 $data = [
     'first_name' => 'John',
     'last_name' => 'Doe',
@@ -31,6 +25,12 @@ $data = [
 
 $result = $validator->validate($data);
 $result->isValid(); // bool(true)
+
+$result->overwriteMessages([
+    'last_name' => [
+        LengthBetween::TOO_LONG => 'Your name is too long.'
+    ]
+]);
 ```
 
 ## Why Particle\Validator?

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -13,21 +13,19 @@ $v->overwriteDefaultMessages([
     LengthBetween::TOO_LONG => 'It\'s too long, that value'
 ]);
 
-$v->overwriteMessages([
-    'first_name' => [
-        LengthBetween::TOO_LONG => 'First name is too long, mate'
-    ]
-]);
-
 $result = $v->validate([
     'first_name' => 'this is too long',
     'last_name' => 'this is also too long',
 ]);
 
+$result->overwriteMessages([
+    'first_name' => [
+        LengthBetween::TOO_LONG => 'First name is too long, mate'
+    ]
+]);
 
+var_dump($result->getMessages());
 /**
- * Output:
- *
  *  [
  *     'first_name' => [
  *         LengthBetween::TOO_LONG => 'First name is too long, mate'
@@ -37,5 +35,4 @@ $result = $v->validate([
  *     ]
  * ];
  */
-var_dump($result->getMessages());
 ```

--- a/docs/multifield-validation.md
+++ b/docs/multifield-validation.md
@@ -1,4 +1,4 @@
-# Multifield validation
+# Multi-field validation
 
 There are situations where you need to use multiple values in your validation. A common use case is having two different
 password fields and need to ensure both are identical. 
@@ -36,7 +36,7 @@ class ConfirmedPasswordRule extends Rule
 {
     const NO_MATCH = 'ConfirmedPasswordRule::NO_MATCH';
     
-    protected $messages = [
+    protected $messageTemplates = [
         self::NO_MATCH => 'Passwords do not match',
     ];
     
@@ -50,5 +50,5 @@ class ConfirmedPasswordRule extends Rule
 }
 ```
 
-Notice the usage of ```$this->values``` in this validate method, which can be used to access other values that are up
+Notice the usage of `$this->values` in this validate method, which can be used to access other values that are up
 for validation.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -40,7 +40,6 @@ $v->required('userId')->callback(function ($value) {
 });
 ```
 
-
 ### datetime($format = null)
 
 Validates that the value is a date. If format is passed, it *must* be in that format.

--- a/docs/validation-result.md
+++ b/docs/validation-result.md
@@ -37,8 +37,9 @@ class MyEntity
         ];
     }
 }
-
-// in a controller:
+```
+And then in your controller:
+```php
 $entity = new Entity();
 $entity->setId($this->getParam('id'));
 
@@ -46,7 +47,7 @@ $result = $entity->validate();
 
 if (!$result->isValid()) {
     return $this->renderTemplate([
-        'messages' => $result->getMessages() // or maybe even just pass in $result.
+        'messages' => $result->getMessages() // or just pass in $result if you want to overwrite specific messages
     ]);
 }
 ```

--- a/src/MessageStack.php
+++ b/src/MessageStack.php
@@ -18,21 +18,21 @@ class MessageStack
     /**
      * Contains a list of all validation messages.
      *
-     * @var array
+     * @var array<string $key, array<string $reason, array<string message, array<mixed $parameters>>>>
      */
     protected $messages = [];
 
     /**
      * Contains an array of field and reason specific message overwrites.
      *
-     * @var array
+     * @var array<string $key, array<string $reason, string message>>
      */
     protected $overwrites = [];
 
     /**
      * Contains an array of global message overwrites.
      *
-     * @var array
+     * @var array<string $key, array<string $reason, string message>>
      */
     protected $defaultMessages = [];
 
@@ -46,15 +46,10 @@ class MessageStack
      */
     public function append($key, $reason, $message, array $parameters)
     {
-        if (isset($this->defaultMessages[$reason])) {
-            $message = $this->defaultMessages[$reason];
-        }
-
-        if (isset($this->overwrites[$key][$reason])) {
-            $message = $this->overwrites[$key][$reason];
-        }
-
-        $this->messages[$key][$reason] = $this->format($message, $parameters);
+        $this->messages[$key][$reason] = [
+            'message' => $message,
+            'parameters' => $parameters,
+        ];
     }
 
     /**
@@ -64,7 +59,18 @@ class MessageStack
      */
     public function getMessages()
     {
-        return $this->messages;
+        $finalMessages = [];
+
+        foreach ($this->messages as $key => $reasons) {
+            foreach ($reasons as $reason => $message) {
+                $finalMessages[$key][$reason] = $this->format(
+                    $this->overwriteFinalMessage($message['message'], $key, $reason),
+                    $message['parameters']
+                );
+            }
+        }
+
+        return $finalMessages;
     }
 
     /**
@@ -89,6 +95,27 @@ class MessageStack
     {
         $this->defaultMessages = $messages;
         return $this;
+    }
+
+    /**
+     * Overwrites a message if overwrites are set
+     *
+     * @param string $message
+     * @param string $key
+     * @param string $reason
+     * @return string
+     */
+    protected function overwriteFinalMessage($message, $key, $reason)
+    {
+        if (isset($this->defaultMessages[$reason])) {
+            $message = $this->defaultMessages[$reason];
+        }
+
+        if (isset($this->overwrites[$key][$reason])) {
+            $message = $this->overwrites[$key][$reason];
+        }
+
+        return $message;
     }
 
     /**

--- a/src/MessageStack.php
+++ b/src/MessageStack.php
@@ -121,7 +121,7 @@ class MessageStack
     /**
      * @param string $message
      * @param array $parameters
-     * @return mixed
+     * @return string
      */
     protected function format($message, array $parameters)
     {

--- a/src/ValidationResult.php
+++ b/src/ValidationResult.php
@@ -21,7 +21,7 @@ class ValidationResult
     protected $isValid;
 
     /**
-     * @var array
+     * @var MessageStack
      */
     protected $messages;
 

--- a/src/ValidationResult.php
+++ b/src/ValidationResult.php
@@ -34,10 +34,10 @@ class ValidationResult
      * Construct the validation result.
      *
      * @param bool $isValid
-     * @param array $messages
+     * @param MessageStack $messages
      * @param array $values
      */
-    public function __construct($isValid, array $messages, array $values)
+    public function __construct($isValid, MessageStack $messages, array $values)
     {
         $this->isValid = $isValid;
         $this->messages = $messages;
@@ -65,13 +65,26 @@ class ValidationResult
     }
 
     /**
+     * Overwrite key-validator specific messages (so [first_name => [Length::TOO_SHORT => 'Message']]).
+     *
+     * @param array $messages
+     * @return $this
+     */
+    public function overwriteMessages(array $messages)
+    {
+        $this->messages->overwriteMessages($messages);
+
+        return $this;
+    }
+
+    /**
      * Returns the array of messages that were collected during validation.
      *
      * @return array
      */
     public function getMessages()
     {
-        return $this->messages;
+        return $this->messages->getMessages();
     }
 
     /**

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -116,7 +116,7 @@ class Validator
 
         return new ValidationResult(
             $isValid,
-            $this->messageStack->getMessages(),
+            $this->messageStack,
             $this->output->getArrayCopy()
         );
     }

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -105,7 +105,7 @@ class Validator
     public function validate(array $values, $context = self::DEFAULT_CONTEXT)
     {
         $isValid = true;
-        $messageStack = $this->buildMessageStack($context);
+        $messageStack = $this->buildMessageStack();
         $this->output = new Container();
         $input = new Container($values);
 

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -149,17 +149,6 @@ class Validator
         $this->context = self::DEFAULT_CONTEXT;
     }
 
-    /** * Overwrite the messages for specific keys.
-     *
-     * @param array $messages
-     * @return $this
-     */
-    public function overwriteMessages(array $messages)
-    {
-        $this->messageOverwrites[$this->context] = $messages;
-        return $this;
-    }
-
     /**
      * Overwrite the default messages with custom messages.
      *

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -130,7 +130,6 @@ class Validator
      */
     public function copyContext($otherContext, callable $callback = null)
     {
-        $this->copyMessages($otherContext);
         $this->copyChains($otherContext, $callback);
 
         return $this;
@@ -200,33 +199,13 @@ class Validator
     /**
      * Build a new MessageStack, set the message overwrites and return it.
      *
-     * @param string $context
      * @return MessageStack
      */
-    protected function buildMessageStack($context)
+    protected function buildMessageStack()
     {
         $this->messageStack = new MessageStack();
         $this->messageStack->overwriteDefaultMessages($this->defaultMessages);
-
-        foreach ([self::DEFAULT_CONTEXT, $context] as $currentContext) {
-            if (isset($this->messageOverwrites[$currentContext])) {
-                $this->messageStack->overwriteMessages($this->messageOverwrites[$currentContext]);
-            }
-        }
-
         return $this->messageStack;
-    }
-
-    /**
-     * Copies the messages of the context $otherContext to the current context.
-     *
-     * @param string $otherContext
-     */
-    protected function copyMessages($otherContext)
-    {
-        if (isset($this->messageOverwrites[$otherContext])) {
-            $this->messageOverwrites[$this->context] = $this->messageOverwrites[$otherContext];
-        }
     }
 
     /**

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -31,65 +31,9 @@ class ContextTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([], $result->getMessages());
     }
 
-    public function testCanHaveIndependentMessages()
-    {
-        $this->validator->context('insert', function (Validator $context) {
-            $context->required('first_name')->length(5);
-
-            $context->overwriteMessages([
-                'first_name' => [
-                    Rule\Length::TOO_SHORT => 'This is from inside the context.'
-                ]
-            ]);
-        });
-
-        $this->validator->overwriteMessages([
-            'first_name' => [
-                Rule\Length::TOO_SHORT => 'This is outside of the context',
-            ]
-        ]);
-
-        $result = $this->validator->validate(['first_name' => 'Rick'], 'insert');
-        $expected = [
-            'first_name' => [
-                Rule\Length::TOO_SHORT => 'This is from inside the context.'
-            ]
-        ];
-        $this->assertEquals($expected, $result->getMessages());
-    }
-
-    public function testMessagesWillBeInheritedFromDefaultContext()
-    {
-        $this->validator->context('insert', function (Validator $context) {
-            $context->required('first_name')->length(5);
-        });
-
-        $this->validator->overwriteMessages([
-            'first_name' => [
-                Rule\Length::TOO_SHORT => 'This is outside of the context',
-            ]
-        ]);
-
-        $result = $this->validator->validate(['first_name' => 'Rick'], 'insert');
-
-        $expected = [
-            'first_name' => [
-                Rule\Length::TOO_SHORT => 'This is outside of the context'
-            ]
-        ];
-
-        $this->assertEquals($expected, $result->getMessages());
-    }
-
     public function testContextCanCopyRulesFromOtherContext()
     {
         $this->validator->context('insert', function (Validator $context) {
-            $context->overwriteMessages([
-                'first_name' => [
-                    Rule\Length::TOO_SHORT => 'From inside the "insert" context.'
-                ]
-            ]);
-
             $context->required('first_name')->length(5);
         });
 
@@ -99,13 +43,6 @@ class ContextTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->validator->validate(['first_name' => 'Rick'], 'update');
         $this->assertFalse($result->isValid());
-
-        $expected = [
-            'first_name' => [
-                Rule\Length::TOO_SHORT => 'From inside the "insert" context.'
-            ]
-        ];
-        $this->assertEquals($expected, $result->getMessages());
     }
 
     public function testContextCopyCanAlterChains()

--- a/tests/Rule/InArrayTest.php
+++ b/tests/Rule/InArrayTest.php
@@ -41,14 +41,14 @@ class InArrayTest extends \PHPUnit_Framework_TestCase
     public function testCanUseTheValuesInErrorMessage()
     {
         $this->validator->required('group')->inArray(['users', 'admins']);
+        $result = $this->validator->validate(['group' => 'none']);
+        $this->assertFalse($result->isValid());
 
-        $this->validator->overwriteMessages([
+        $result->overwriteMessages([
             'group' => [
                 InArray::NOT_IN_ARRAY => '{{ name }} must be one of {{ values }}'
             ]
         ]);
-        $result = $this->validator->validate(['group' => 'none']);
-        $this->assertFalse($result->isValid());
 
         $expected = [
             'group' => [

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -20,12 +20,12 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
     public function testCanOverwriteSpecificMessages()
     {
         $this->validator->required('foo');
-        $this->validator->overwriteMessages([
+        $result = $this->validator->validate([]);
+        $result->overwriteMessages([
             'foo' => [
                 Required::NON_EXISTENT_KEY => 'This is my overwritten message. The key was "{{ key }}".'
             ]
         ]);
-        $result = $this->validator->validate([]);
 
         $this->assertFalse($result->isValid());
         $this->assertEquals(
@@ -72,16 +72,16 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
             Rule\Length::TOO_SHORT => 'This is overwritten globally.'
         ]);
 
-        $this->validator->overwriteMessages([
-            'first_name' => [
-                Rule\Length::TOO_SHORT => 'This is overwritten for first_name only.'
-            ]
-        ]);
-
         $this->validator->required('first_name')->length(5);
 
         $result = $this->validator->validate(['first_name' => 'Rick']);
         $this->assertFalse($result->isValid());
+
+        $result->overwriteMessages([
+            'first_name' => [
+                Rule\Length::TOO_SHORT => 'This is overwritten for first_name only.'
+            ]
+        ]);
 
         $expected = [
             'first_name' => [


### PR DESCRIPTION
### What

This PR adds support to overwrite validation messages on the validation result. This could come in handy overwriting validation messages in a view (when using MVC).

### How to test

1. See that you can overwrite validation messages in the validation result, including message variables
1. See that you can no longer overwrite specific messages on the validator
1. See that all tests pass and coverage/quality is still 100%

### ToDo

* [x] Update documentation
* [x] Remove `->overwriteMessages()` from the `Validator` class.