### PR TITLE
Add output rules functionality with name, options and messages

### DIFF
--- a/src/Chain.php
+++ b/src/Chain.php
@@ -337,6 +337,26 @@ class Chain
     }
 
     /**
+     * Get all rules applied to this chain
+     */
+    public function getRules()
+    {
+        $rules = [];
+
+        /** @var Rule $rule */
+        foreach ($this->rules as $rule) {
+            $reflectionRule = new \ReflectionClass($rule);
+            $rules[] = [
+                'name' => $reflectionRule->getShortName(),
+                'messageParameters' => $rule->getMessageParameters(),
+                'messageTemplates' => $rule->getMessageTemplates(),
+            ];
+        }
+
+        return $rules;
+    }
+
+    /**
      * Shortcut method for storing a rule on this chain, and returning the chain.
      *
      * @param Rule $rule

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -83,6 +83,16 @@ abstract class Rule
     }
 
     /**
+     * Get all message templates for this rule
+     *
+     * @return array
+     */
+    public function getMessageTemplates()
+    {
+        return $this->messageTemplates;
+    }
+
+    /**
      * Sets the default parameters for each validation rule (key and name).
      *
      * @param string $key
@@ -131,7 +141,7 @@ abstract class Rule
      *
      * @return array
      */
-    protected function getMessageParameters()
+    public function getMessageParameters()
     {
         $name = isset($this->name) ? $this->name : str_replace('_', ' ', $this->key);
 

--- a/src/Rule/Between.php
+++ b/src/Rule/Between.php
@@ -111,7 +111,7 @@ class Between extends Rule
      *
      * @return array
      */
-    protected function getMessageParameters()
+    public function getMessageParameters()
     {
         return array_merge(parent::getMessageParameters(), [
             'min' => $this->min,

--- a/src/Rule/Equal.php
+++ b/src/Rule/Equal.php
@@ -65,7 +65,7 @@ class Equal extends Rule
      *
      * @return array
      */
-    protected function getMessageParameters()
+    public function getMessageParameters()
     {
         return array_merge(parent::getMessageParameters(), [
             'testvalue' => $this->value

--- a/src/Rule/GreaterThan.php
+++ b/src/Rule/GreaterThan.php
@@ -80,7 +80,7 @@ class GreaterThan extends Rule
      *
      * @return array
      */
-    protected function getMessageParameters()
+    public function getMessageParameters()
     {
         return array_merge(parent::getMessageParameters(), [
             'min' => $this->min,

--- a/src/Rule/InArray.php
+++ b/src/Rule/InArray.php
@@ -76,7 +76,7 @@ class InArray extends Rule
      *
      * @return array
      */
-    protected function getMessageParameters()
+    public function getMessageParameters()
     {
         $quote = function ($value) {
             return '"' . $value . '"';

--- a/src/Rule/Length.php
+++ b/src/Rule/Length.php
@@ -78,7 +78,7 @@ class Length extends Rule
      *
      * @return array
      */
-    protected function getMessageParameters()
+    public function getMessageParameters()
     {
         return array_merge(parent::getMessageParameters(), [
             'length' => $this->length

--- a/src/Rule/LengthBetween.php
+++ b/src/Rule/LengthBetween.php
@@ -94,7 +94,7 @@ class LengthBetween extends Between
      *
      * @return array
      */
-    protected function getMessageParameters()
+    public function getMessageParameters()
     {
         return array_merge(parent::getMessageParameters(), [
             'min' => $this->min,

--- a/src/Rule/LessThan.php
+++ b/src/Rule/LessThan.php
@@ -80,7 +80,7 @@ class LessThan extends Rule
      *
      * @return array
      */
-    protected function getMessageParameters()
+    public function getMessageParameters()
     {
         return array_merge(parent::getMessageParameters(), [
             'max' => $this->max,

--- a/src/Rule/Uuid.php
+++ b/src/Rule/Uuid.php
@@ -84,7 +84,7 @@ class Uuid extends Regex
      *
      * @return array
      */
-    protected function getMessageParameters()
+    public function getMessageParameters()
     {
         return array_merge(parent::getMessageParameters(), [
             'version' => $this->version

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -173,6 +173,64 @@ class Validator
     }
 
     /**
+     * Output all rules set on the validator.
+     * The output can be build with a custom formatter in a closure, and will contain an array with all rules
+     * If no callable formatter is provided, the array with rules will be returned directly
+     *
+     * @param callable|null $formatter
+     * @param string $context
+     * @return array|mixed
+     */
+    public function output(callable $formatter = null, $context = self::DEFAULT_CONTEXT)
+    {
+        $ruleSet = $this->getRuleSet($context);
+
+        if ($formatter === null) {
+            return $ruleSet;
+        }
+
+        return call_user_func($formatter, $ruleSet);
+    }
+
+    /**
+     * Returns an array containing all rules added to the specified context
+     *
+     * @param $context
+     * @return array
+     */
+    protected function getRuleSet($context)
+    {
+        $ruleSet = [];
+
+        /**
+         * @var string $subject
+         * @var Chain $chain
+         */
+        foreach ($this->chains[$context] as $subject => $chain) {
+            $subjectRules = $chain->getRules();
+
+            $rules = [];
+
+            foreach ($subjectRules as $subjectRule) {
+
+                // @todo: overwrite messages
+
+                $options = $subjectRule['messageParameters'];
+                unset($options['key'], $options['name']);
+
+                $rules[] = [
+                    'name' => $subjectRule['name'],
+                    'options' => $options,
+                ];
+            }
+
+            $ruleSet[$subject] = $rules;
+        }
+
+        return $ruleSet;
+    }
+
+    /**
      * Retrieves a Chain object, or builds one if it doesn't exist yet.
      *
      * @param string $key

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -212,7 +212,6 @@ class Validator
             $rules = [];
 
             foreach ($subjectRules as $subjectRule) {
-
                 // @todo: overwrite messages
 
                 $options = $subjectRule['messageParameters'];

--- a/tests/ValidatorOutputTest.php
+++ b/tests/ValidatorOutputTest.php
@@ -1,0 +1,112 @@
+<?php
+namespace Particle\Tests;
+
+use Particle\Validator\Rule;
+use Particle\Validator\Validator;
+
+class ValidatorOutputTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Validator
+     */
+    protected $validator;
+
+    /**
+     * Set the validator for local usage
+     */
+    public function setUp()
+    {
+        $this->validator = new Validator();
+    }
+
+    /**
+     * Check if the returned rules array is what is expected
+     */
+    public function testOutputRulesArray()
+    {
+        $this->validator->required('first_name')->length(2);
+
+        $output = $this->validator->output();
+
+        $expected = [
+            'first_name' => [
+                [
+                    'name' => 'Required',
+                    'options' => [],
+                ],
+                [
+                    'name' => 'NotEmpty',
+                    'options' => [],
+                ],
+                [
+                    'name' => 'Length',
+                    'options' => [
+                        'length' => 2,
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $output);
+    }
+
+    /**
+     * Check if the returned rules array is what is expected
+     */
+//    public function testOutputRulesArrayCustomMessages()
+//    {
+//        $this->validator->required('first_name')->length(2);
+//
+//        $this->validator->overWriteMessages([
+//            'first_name' => [
+//                Rule\Length::TOO_SHORT => 'Your first name is too short bro!',
+//                Rule\Length::TOO_LONG => 'Your first name is too long bro!',
+//            ],
+//        ]);
+//
+//        $output = $this->validator->output();
+//
+//        $expected = [
+//            Rule\Length::TOO_SHORT => 'Your first name is too short bro',
+//            Rule\Length::TOO_LONG => 'Your first name is too long bro!',
+//        ];
+//
+//        $this->assertEquals($expected, $output['first_name'][2]['messages']);
+//    }
+
+    /**
+     * Check that an empty array is returned when no rules have been defined
+     */
+    public function testOutputEmptyRulesArray()
+    {
+        $output = $this->validator->output();
+
+        $this->assertEquals([], $output);
+    }
+
+    /**
+     * Test that the output could be converted to json
+     */
+    public function testOutputJson()
+    {
+        $output = $this->validator->output(function($ruleSet) {
+            return json_encode($ruleSet);
+        });
+
+        $this->assertSame('[]', $output);
+    }
+
+    /**
+     * Test that the output could be converted to json
+     */
+    public function testOutputJsonWithRules()
+    {
+        $this->validator->required('first_name')->length(2);
+
+        $output = $this->validator->output(function($ruleSet) {
+            return json_encode($ruleSet);
+        });
+
+        $this->assertSame('[]', $output);
+    }
+}

--- a/tests/ValidatorOutputTest.php
+++ b/tests/ValidatorOutputTest.php
@@ -89,7 +89,7 @@ class ValidatorOutputTest extends \PHPUnit_Framework_TestCase
      */
     public function testOutputJson()
     {
-        $output = $this->validator->output(function($ruleSet) {
+        $output = $this->validator->output(function ($ruleSet) {
             return json_encode($ruleSet);
         });
 
@@ -103,10 +103,14 @@ class ValidatorOutputTest extends \PHPUnit_Framework_TestCase
     {
         $this->validator->required('first_name')->length(2);
 
-        $output = $this->validator->output(function($ruleSet) {
+        $output = $this->validator->output(function ($ruleSet) {
             return json_encode($ruleSet);
         });
 
-        $this->assertSame('[]', $output);
+        $expectedJson = '{"first_name":[{"name":"Required","options":[]},'
+            . '{"name":"NotEmpty","options":[]},'
+            . '{"name":"Length","options":{"length":2}}]}';
+
+        $this->assertSame($expectedJson, $output);
     }
 }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -179,7 +179,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
     /**
      * Bug fix test: Check if no notice is shown when no validation rules are configured.
      */
-    public function testUnconfiguredValidatorWillNotShowNotice()
+    public function testNotConfiguredValidatorWillNotShowNotice()
     {
         $this->assertTrue($this->validator->validate(['value' => 'yes'])->isValid());
     }


### PR DESCRIPTION
### What

Output the rules of the validator and format them in a way you would like.

### How to test

1. See that unit tests have been added
1. See that the code coverage is 100% and code quality is 100%
1. See that all tests pass
1. See that you can output the rules in an array if no callable is given, and that you can format the resulted rules with a callable

### ToDo

* [ ] Include messages in the output
* [ ] Update documentation

### Issue

https://github.com/particle-php/Validator/issues/80