### PR TITLE
Adding output functionality

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,11 @@
             "Particle\\Validator\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Particle\\Validator\\Tests\\": "tests/"
+        }
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "2.0-dev"

--- a/docs/output.md
+++ b/docs/output.md
@@ -1,0 +1,167 @@
+# Output structure
+
+Particle\Validator can output its entire internal structure by means of passing that structure to
+a callable. This means that outputting to a certain format is not part of the library, nor will it
+ever be, these will live in separate libraries.
+
+Outputting to your own format is quite easy:
+
+```php
+$v = new Validator;
+$v->required('email')->email();
+$v->optional('firstname')->allowEmpty(true)->lengthBetween(0, 20);
+
+$output = $v->output(function (Structure $structure) {
+    $output = [];
+
+    // $structure contains all "subjects" that should be validated (e.g. email and firstname).
+    foreach ($structure->getSubjects() as $subject) {
+        // Subject contains all rules for the subject.
+
+        foreach ($subject->getRules() as $rule) {
+            // $rule contains information on the rule that is bound to the subject.
+            $output[$subject->getKey()][] = [
+                'rule' => $rule->getName(), // e.g. "Email"
+                'messages' => $rule->getMessages(), // All validation messages.
+                'parameters' => $rule->getParameters(), // All parameters for this rule.
+            ];
+        }
+    }
+
+    return json_encode($output);
+});
+```
+
+This will yield the following result:
+
+```json
+{
+    "email": [
+        {
+            "rule": "Required",
+            "messages": {
+                "Required::NON_EXISTENT_KEY": "{{ key }} must be provided, but does not exist"
+            },
+            "parameters": {
+                "key": "email",
+                "name": "email",
+                "required": true,
+                "callback": null
+            }
+        },
+        {
+            "rule": "NotEmpty",
+            "messages": {
+                "NotEmpty::EMPTY_VALUE": "{{ name }} must not be empty"
+            },
+            "parameters": {
+                "key": "email",
+                "name": "email",
+                "allowEmpty": false,
+                "callback": null
+            }
+        },
+        {
+            "rule": "Email",
+            "messages": {
+                "Email::INVALID_VALUE": "{{ name }} must be a valid email address"
+            },
+            "parameters": {
+                "key": "email",
+                "name": "email"
+            }
+        }
+    ],
+    "firstname": [
+        {
+            "rule": "Required",
+            "messages": {
+                "Required::NON_EXISTENT_KEY": "{{ key }} must be provided, but does not exist"
+            },
+            "parameters": {
+                "key": "firstname",
+                "name": "firstname",
+                "required": false,
+                "callback": null
+            }
+        },
+        {
+            "rule": "NotEmpty",
+            "messages": {
+                "NotEmpty::EMPTY_VALUE": "{{ name }} must not be empty"
+            },
+            "parameters": {
+                "key": "firstname",
+                "name": "firstname",
+                "allowEmpty": true,
+                "callback": null
+            }
+        },
+        {
+            "rule": "LengthBetween",
+            "messages": {
+                "LengthBetween::TOO_LONG": "{{ name }} must be shorter than {{ max }} characters",
+                "LengthBetween::TOO_SHORT": "{{ name }} must be longer than {{ min }} characters"
+            },
+            "parameters": {
+                "key": "firstname",
+                "name": "firstname",
+                "min": 0,
+                "max": 20
+            }
+        }
+    ]
+}
+```
+
+## Outputting callbacks
+
+Callbacks in the form of closures can not be outputted, because of the fact that there's no string
+representation of the closure. If you want to output callable variables, so that you can re-use the
+same logic in javascript for example, you should create a callable object that has a `__toString`
+method.
+
+For example:
+
+```php
+class Statement
+{
+    protected $representation;
+    protected $callable;
+
+    public function __construct($representation, Callable $callable)
+    {
+        $this->representation = $representation;
+        $this->callable = $callable;
+    }
+
+    public function __invoke($value, array $context)
+    {
+        return call_user_func($this->callable, $value, $context);
+    }
+
+    public function __toString()
+    {
+        return $this->representation;
+    }
+}
+
+$v = new Validator;
+$v->required('foo')->callback(new Statement('foo !== bar', function ($value, array $context) {
+    return $value !== $context['bar'];
+});
+
+$output = $v->output(function (Structure $structure) {
+    $subject = $structure->getSubjects()[0];
+    $rule = $subject->getRules()[2]; // 2 is the "callback" rule.
+    $parameters = $rule->getParameters();
+
+    return $parameters['callback'];
+});
+
+echo $output; // "foo !== bar".
+```
+
+Of course, you could even use a language that can be parsed by PHP and JS alike, such as
+[Symfony Expression Language](http://symfony.com/doc/current/components/expression_language/index.html)
+or [Hoa\Ruler](https://github.com/hoaproject/Ruler).

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -8,6 +8,8 @@
  */
 namespace Particle\Validator;
 
+use Particle\Validator\Output\Structure;
+use Particle\Validator\Output\Subject;
 use Particle\Validator\Value\Container;
 
 /**
@@ -308,6 +310,26 @@ class Chain
     {
         $this->getNotEmptyRule()->setAllowEmpty($allowEmpty);
         return $this;
+    }
+
+    /**
+     * Attach a representation of this Chain to the Output\Structure $structure.
+     *
+     * @internal
+     * @param Structure $structure
+     * @return Structure
+     */
+    public function output(Structure $structure)
+    {
+        $subject = new Subject($this->key, $this->name);
+
+        foreach ($this->rules as $rule) {
+            $rule->output($subject, $this->key, $this->name);
+        }
+
+        $structure->addSubject($subject);
+
+        return $structure;
     }
 
     /**

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -325,7 +325,7 @@ class Chain
         $subject = new Subject($this->key, $this->name);
 
         foreach ($this->rules as $rule) {
-            $rule->output($subject, $messageStack, $this->key, $this->name);
+            $rule->output($subject, $messageStack);
         }
 
         $structure->addSubject($subject);

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -317,14 +317,15 @@ class Chain
      *
      * @internal
      * @param Structure $structure
+     * @param MessageStack $messageStack
      * @return Structure
      */
-    public function output(Structure $structure)
+    public function output(Structure $structure, MessageStack $messageStack)
     {
         $subject = new Subject($this->key, $this->name);
 
         foreach ($this->rules as $rule) {
-            $rule->output($subject, $this->key, $this->name);
+            $rule->output($subject, $messageStack, $this->key, $this->name);
         }
 
         $structure->addSubject($subject);

--- a/src/Exception/NoSuchContextException.php
+++ b/src/Exception/NoSuchContextException.php
@@ -1,8 +1,0 @@
-<?php
-namespace Particle\Validator\Exception;
-
-use Particle\Validator\ExceptionInterface;
-
-class NoSuchContextException extends \Exception implements ExceptionInterface
-{
-}

--- a/src/Exception/NoSuchContextException.php
+++ b/src/Exception/NoSuchContextException.php
@@ -1,0 +1,8 @@
+<?php
+namespace Particle\Validator\Exception;
+
+use Particle\Validator\ExceptionInterface;
+
+class NoSuchContextException extends \Exception implements ExceptionInterface
+{
+}

--- a/src/MessageStack.php
+++ b/src/MessageStack.php
@@ -66,7 +66,7 @@ class MessageStack
      */
     public function getOverwrite($reason, $key)
     {
-        if (isset($this->overwrites[$key][$reason])) {
+        if ($this->hasOverwrite($key, $reason)) {
             return $this->overwrites[$key][$reason];
         }
 
@@ -175,10 +175,22 @@ class MessageStack
     {
         foreach ($messageStack->overwrites as $key => $reasons) {
             foreach ($reasons as $reason => $message) {
-                if (!isset($this->overwrites[$key][$reason])) {
+                if (!$this->hasOverwrite($key, $reason)) {
                     $this->overwrites[$key][$reason] = $message;
                 }
             }
         }
+    }
+
+    /**
+     * Returns whether an overwrite exists for the key $key with reason $reason.
+     *
+     * @param string $key
+     * @param string $reason
+     * @return bool
+     */
+    protected function hasOverwrite($key, $reason)
+    {
+        return isset($this->overwrites[$key][$reason]);
     }
 }

--- a/src/MessageStack.php
+++ b/src/MessageStack.php
@@ -181,5 +181,4 @@ class MessageStack
             }
         }
     }
-
 }

--- a/src/MessageStack.php
+++ b/src/MessageStack.php
@@ -58,6 +58,26 @@ class MessageStack
     }
 
     /**
+     * Returns an overwrite (either default or specific message) for the reason and key, or false.
+     *
+     * @param string $reason
+     * @param string $key
+     * @return string|bool
+     */
+    public function getOverwrite($reason, $key)
+    {
+        if (isset($this->overwrites[$key][$reason])) {
+            return $this->overwrites[$key][$reason];
+        }
+
+        if (array_key_exists($reason, $this->defaultMessages)) {
+            return $this->defaultMessages[$reason];
+        }
+
+        return false;
+    }
+
+    /**
      * Returns a list of all messages.
      *
      * @return array
@@ -161,4 +181,5 @@ class MessageStack
             }
         }
     }
+
 }

--- a/src/MessageStack.php
+++ b/src/MessageStack.php
@@ -92,9 +92,33 @@ class MessageStack
     }
 
     /**
+     * Merges an existing MessageStack into this one by taking over it's overwrites and defaults.
+     *
+     * @param MessageStack $messageStack
+     */
+    public function merge(MessageStack $messageStack)
+    {
+        $this->mergeDefaultMessages($messageStack);
+        $this->mergeOverwrites($messageStack);
+    }
+
+    /**
+     * Reset the messages to an empty array.
+     *
+     * @return $this
+     */
+    public function reset()
+    {
+        $this->messages = [];
+        return $this;
+    }
+
+    /**
+     * Formats the message $message with $parameters by replacing {{ name }} with $parameters['name'].
+     *
      * @param string $message
      * @param array $parameters
-     * @return mixed
+     * @return string
      */
     protected function format($message, array $parameters)
     {
@@ -106,5 +130,35 @@ class MessageStack
         };
 
         return preg_replace_callback('~{{\s*([^}\s]+)\s*}}~', $replace, $message);
+    }
+
+    /**
+     * Merges the default messages from $messageStack to this MessageStack.
+     *
+     * @param MessageStack $messageStack
+     */
+    protected function mergeDefaultMessages(MessageStack $messageStack)
+    {
+        foreach ($messageStack->defaultMessages as $key => $message) {
+            if (!array_key_exists($key, $this->defaultMessages)) {
+                $this->defaultMessages[$key] = $message;
+            }
+        }
+    }
+
+    /**
+     * Merges the message overwrites from $messageStack to this MessageStack.
+     *
+     * @param MessageStack $messageStack
+     */
+    protected function mergeOverwrites(MessageStack $messageStack)
+    {
+        foreach ($messageStack->overwrites as $key => $reasons) {
+            foreach ($reasons as $reason => $message) {
+                if (!isset($this->overwrites[$key][$reason])) {
+                    $this->overwrites[$key][$reason] = $message;
+                }
+            }
+        }
     }
 }

--- a/src/Output/Rule.php
+++ b/src/Output/Rule.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/validator/blob/master/LICENSE New BSD License
+ */
+namespace Particle\Validator\Output;
+
+/**
+ * The Rule class is a representation of an actual rule for displaying purposes.
+ *
+ * @package Particle\Validator
+ */
+class Rule
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var array
+     */
+    protected $messages;
+
+    /**
+     * @var array
+     */
+    protected $parameters;
+
+    /**
+     * @param string $name
+     * @param array $messages
+     * @param array $parameters
+     */
+    public function __construct($name, array $messages, array $parameters)
+    {
+        $this->name = $name;
+        $this->messages = $messages;
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * Returns the name (short class name) for this rule.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Returns all messages for this rule.
+     *
+     * @return array
+     */
+    public function getMessages()
+    {
+        return $this->messages;
+    }
+
+    /**
+     * Returns all parameters for this rule.
+     *
+     * @return array
+     */
+    public function getParameters()
+    {
+        return $this->parameters;
+    }
+}

--- a/src/Output/Structure.php
+++ b/src/Output/Structure.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/validator/blob/master/LICENSE New BSD License
+ */
+namespace Particle\Validator\Output;
+
+/**
+ * Structure is an object for communicating the internal state and structure of Validator to an output object.
+ *
+ * @package Particle\Validator\Output
+ */
+class Structure
+{
+    /**
+     * @var Subject[]
+     */
+    protected $subjects;
+
+    /**
+     * Add a subject (representation of Chain) to the structure.
+     *
+     * @param Subject $subject
+     */
+    public function addSubject(Subject $subject)
+    {
+        $this->subjects[] = $subject;
+    }
+
+    /**
+     * Returns an array of all subjects.
+     *
+     * @return Subject[]
+     */
+    public function getSubjects()
+    {
+        return $this->subjects;
+    }
+}

--- a/src/Output/Subject.php
+++ b/src/Output/Subject.php
@@ -61,6 +61,16 @@ class Subject
     }
 
     /**
+     * Returns the name for this subject.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
      * Returns an array of all rules in this subject.
      *
      * @return Rule[]

--- a/src/Output/Subject.php
+++ b/src/Output/Subject.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/validator/blob/master/LICENSE New BSD License
+ */
+namespace Particle\Validator\Output;
+
+/**
+ * Subject is an object for communicating the internal state of a Chain to an output object.
+ *
+ * @package Particle\Validator\Output
+ */
+class Subject
+{
+    /**
+     * @var string
+     */
+    protected $key;
+
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var Rule[]
+     */
+    protected $rules;
+
+    /**
+     * @param string $key
+     * @param string $name
+     */
+    public function __construct($key, $name)
+    {
+        $this->key = $key;
+        $this->name = $name;
+    }
+
+    /**
+     * Adds a rule for this subject.
+     *
+     * @param Rule $rule
+     */
+    public function addRule(Rule $rule)
+    {
+        $this->rules[] = $rule;
+    }
+
+    /**
+     * Returns the key for this subject.
+     *
+     * @return string
+     */
+    public function getKey()
+    {
+        return $this->key;
+    }
+
+    /**
+     * Returns an array of all rules in this subject.
+     *
+     * @return Rule[]
+     */
+    public function getRules()
+    {
+        return $this->rules;
+    }
+}

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -8,6 +8,7 @@
  */
 namespace Particle\Validator;
 
+use Particle\Validator\Output\Subject;
 use Particle\Validator\Value\Container;
 
 /**
@@ -109,6 +110,25 @@ abstract class Rule
     }
 
     /**
+     * Attach a representation of this rule to the Output\Subject $subject.
+     *
+     * @internal
+     * @param Subject $subject
+     */
+    public function output(Subject $subject, $key, $name)
+    {
+        $this->setParameters($key, $name);
+
+        $outputRule = new Output\Rule(
+            $this->getShortName(),
+            $this->messageTemplates,
+            $this->getMessageParameters()
+        );
+
+        $subject->addRule($outputRule);
+    }
+
+    /**
      * Appends the error for reason $reason to the MessageStack.
      *
      * @param string $reason
@@ -155,5 +175,15 @@ abstract class Rule
         }
 
         return $messageTemplate;
+    }
+
+    /**
+     * Returns the name of this class, without the namespace.
+     *
+     * @return string
+     */
+    protected function getShortName()
+    {
+        return substr(get_class($this), strrpos(get_class($this), '\\') + 1);
     }
 }

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -115,12 +115,10 @@ abstract class Rule
      * @internal
      * @param Subject $subject
      * @param MessageStack $messageStack
-     * @param string $key
-     * @param string $name
      */
-    public function output(Subject $subject, MessageStack $messageStack, $key, $name)
+    public function output(Subject $subject, MessageStack $messageStack)
     {
-        $this->setParameters($key, $name);
+        $this->setParameters($subject->getKey(), $subject->getName());
 
         $outputRule = new Output\Rule(
             $this->getShortName(),

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -114,14 +114,17 @@ abstract class Rule
      *
      * @internal
      * @param Subject $subject
+     * @param MessageStack $messageStack
+     * @param string $key
+     * @param string $name
      */
-    public function output(Subject $subject, $key, $name)
+    public function output(Subject $subject, MessageStack $messageStack, $key, $name)
     {
         $this->setParameters($key, $name);
 
         $outputRule = new Output\Rule(
             $this->getShortName(),
-            $this->messageTemplates,
+            $this->getMessageTemplates($messageStack),
             $this->getMessageParameters()
         );
 
@@ -185,5 +188,25 @@ abstract class Rule
     protected function getShortName()
     {
         return substr(get_class($this), strrpos(get_class($this), '\\') + 1);
+    }
+
+    /**
+     * Get an array of Message Templates to be returned in output.
+     *
+     * @param MessageStack $messageStack
+     * @return array
+     */
+    protected function getMessageTemplates(MessageStack $messageStack)
+    {
+        $messages = $this->messageTemplates;
+        foreach ($messages as $reason => $message) {
+            $overwrite = $messageStack->getOverwrite($reason, $this->key);
+
+            if (is_string($overwrite)) {
+                $messages[$reason] = $overwrite;
+            }
+        }
+
+        return $messages;
     }
 }

--- a/src/Rule/Callback.php
+++ b/src/Rule/Callback.php
@@ -76,6 +76,17 @@ class Callback extends Rule
         }
     }
 
+    protected function getMessageParameters()
+    {
+        $values = [];
+
+        if (is_object($this->callback) && method_exists($this->callback, '__toString')) {
+            $values['callback'] = (string) $this->callback;
+        }
+
+        return array_merge(parent::getMessageParameters(), $values);
+    }
+
     /**
      * Validates the value according to this rule, and returns the result as a bool.
      *

--- a/src/Rule/Callback.php
+++ b/src/Rule/Callback.php
@@ -8,6 +8,7 @@
  */
 namespace Particle\Validator\Rule;
 
+use Particle\Validator\StringifyCallbackTrait;
 use Particle\Validator\Exception\InvalidValueException;
 use Particle\Validator\Rule;
 use Particle\Validator\Value\Container;
@@ -19,6 +20,8 @@ use Particle\Validator\Value\Container;
  */
 class Callback extends Rule
 {
+    use StringifyCallbackTrait;
+
     /**
      * A constant that will be used to indicate that the callback returned false.
      */
@@ -76,15 +79,14 @@ class Callback extends Rule
         }
     }
 
+    /**
+     * {@inheritdoc}
+     */
     protected function getMessageParameters()
     {
-        $values = [];
-
-        if (is_object($this->callback) && method_exists($this->callback, '__toString')) {
-            $values['callback'] = (string) $this->callback;
-        }
-
-        return array_merge(parent::getMessageParameters(), $values);
+        return array_merge(parent::getMessageParameters(), [
+            'callback' => $this->getCallbackAsString($this->callback),
+        ]);
     }
 
     /**

--- a/src/Rule/NotEmpty.php
+++ b/src/Rule/NotEmpty.php
@@ -8,6 +8,7 @@
  */
 namespace Particle\Validator\Rule;
 
+use Particle\Validator\Output\Subject;
 use Particle\Validator\Rule;
 use Particle\Validator\Value\Container;
 
@@ -67,7 +68,7 @@ class NotEmpty extends Rule
      */
     public function __construct($allowEmpty)
     {
-        $this->allowEmpty = $allowEmpty;
+        $this->allowEmpty = (bool) $allowEmpty;
     }
 
     /**
@@ -136,6 +137,23 @@ class NotEmpty extends Rule
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function getMessageParameters()
+    {
+        $values = [
+            'allowEmpty' => $this->allowEmpty,
+            'callback' => null,
+        ];
+
+        if (is_object($this->allowEmptyCallback) && method_exists($this->allowEmptyCallback, '__toString')) {
+            $values['callback'] = (string) $this->allowEmptyCallback;
+        }
+
+        return array_merge(parent::getMessageParameters(), $values);
+    }
+
+    /**
      * Overwrite the allow empty requirement after instantiation of this rule.
      *
      * @param bool $allowEmpty
@@ -168,7 +186,7 @@ class NotEmpty extends Rule
     protected function allowEmpty(Container $input)
     {
         if (isset($this->allowEmptyCallback)) {
-            $this->allowEmpty = call_user_func_array($this->allowEmptyCallback, [$input->getArrayCopy()]);
+            $this->allowEmpty = call_user_func($this->allowEmptyCallback, $input->getArrayCopy());
         }
         return $this->allowEmpty;
     }

--- a/src/Rule/NotEmpty.php
+++ b/src/Rule/NotEmpty.php
@@ -8,6 +8,7 @@
  */
 namespace Particle\Validator\Rule;
 
+use Particle\Validator\StringifyCallbackTrait;
 use Particle\Validator\Rule;
 use Particle\Validator\Value\Container;
 
@@ -18,6 +19,8 @@ use Particle\Validator\Value\Container;
  */
 class NotEmpty extends Rule
 {
+    use StringifyCallbackTrait;
+
     /**
      * The error code for when a value is empty while this is not allowed.
      */
@@ -140,16 +143,10 @@ class NotEmpty extends Rule
      */
     protected function getMessageParameters()
     {
-        $values = [
+        return array_merge(parent::getMessageParameters(), [
             'allowEmpty' => $this->allowEmpty,
-            'callback' => null,
-        ];
-
-        if (is_object($this->allowEmptyCallback) && method_exists($this->allowEmptyCallback, '__toString')) {
-            $values['callback'] = (string) $this->allowEmptyCallback;
-        }
-
-        return array_merge(parent::getMessageParameters(), $values);
+            'callback' => $this->getCallbackAsString($this->allowEmptyCallback)
+        ]);
     }
 
     /**

--- a/src/Rule/NotEmpty.php
+++ b/src/Rule/NotEmpty.php
@@ -8,7 +8,6 @@
  */
 namespace Particle\Validator\Rule;
 
-use Particle\Validator\Output\Subject;
 use Particle\Validator\Rule;
 use Particle\Validator\Value\Container;
 

--- a/src/Rule/Required.php
+++ b/src/Rule/Required.php
@@ -8,6 +8,7 @@
  */
 namespace Particle\Validator\Rule;
 
+use Particle\Validator\StringifyCallbackTrait;
 use Particle\Validator\Rule;
 use Particle\Validator\Value\Container;
 
@@ -18,6 +19,8 @@ use Particle\Validator\Value\Container;
  */
 class Required extends Rule
 {
+    use StringifyCallbackTrait;
+
     /**
      * The error code when a required field doesn't exist.
      */
@@ -155,18 +158,11 @@ class Required extends Rule
      */
     protected function getMessageParameters()
     {
-        $values = [
+        return array_merge(parent::getMessageParameters(), [
             'required' => $this->required,
-            'callback' => null,
-        ];
-
-        if (is_object($this->requiredCallback) && method_exists($this->requiredCallback, '__toString')) {
-            $values['callback'] = (string) $this->requiredCallback;
-        }
-
-        return array_merge(parent::getMessageParameters(), $values);
+            'callback' => $this->getCallbackAsString($this->requiredCallback)
+        ]);
     }
-
 
     /**
      * Determines if the value is required.

--- a/src/Rule/Required.php
+++ b/src/Rule/Required.php
@@ -8,6 +8,8 @@
  */
 namespace Particle\Validator\Rule;
 
+use Particle\Validator\Output\Structure;
+use Particle\Validator\Output\Subject;
 use Particle\Validator\Rule;
 use Particle\Validator\Value\Container;
 
@@ -149,6 +151,24 @@ class Required extends Rule
         $this->requiredCallback = $requiredCallback;
         return $this;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getMessageParameters()
+    {
+        $values = [
+            'required' => $this->required,
+            'callback' => null,
+        ];
+
+        if (is_object($this->requiredCallback) && method_exists($this->requiredCallback, '__toString')) {
+            $values['callback'] = (string) $this->requiredCallback;
+        }
+
+        return array_merge(parent::getMessageParameters(), $values);
+    }
+
 
     /**
      * Determines if the value is required.

--- a/src/Rule/Required.php
+++ b/src/Rule/Required.php
@@ -8,8 +8,6 @@
  */
 namespace Particle\Validator\Rule;
 
-use Particle\Validator\Output\Structure;
-use Particle\Validator\Output\Subject;
 use Particle\Validator\Rule;
 use Particle\Validator\Value\Container;
 

--- a/src/StringifyCallbackTrait.php
+++ b/src/StringifyCallbackTrait.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/validator/blob/master/LICENSE New BSD License
+ */
+namespace Particle\Validator;
+
+/**
+ * This Trait is for rendering callable objects to a string, if that's possible.
+ *
+ * @package Particle\Validator
+ */
+trait StringifyCallbackTrait
+{
+    /**
+     * Returns a string representation of a callback, if it implements the __toString method.
+     *
+     * @param callable|null $callback
+     * @return string
+     */
+    protected function getCallbackAsString($callback)
+    {
+        if (is_object($callback) && method_exists($callback, '__toString')) {
+            return (string) $callback;
+        }
+        return '';
+    }
+}

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -137,19 +137,41 @@ class Validator
     }
 
     /**
-     * Create a new validation context with the closure $closure.
+     * Create a new validation context with the callback $callback.
      *
      * @param string $name
-     * @param \Closure $closure
+     * @param callable $callback
      */
-    public function context($name, \Closure $closure)
+    public function context($name, callable $callback)
     {
         $this->context = $name;
-        $closure($this);
+        call_user_func($callback, $this);
         $this->context = self::DEFAULT_CONTEXT;
     }
 
-    /** * Overwrite the messages for specific keys.
+    /**
+     * Output the structure of the Validator by calling the $output callable with a representation of Validators'
+     * internal structure.
+     *
+     * @param callable $output
+     * @param string $context
+     * @return mixed
+     */
+    public function output(callable $output, $context = self::DEFAULT_CONTEXT)
+    {
+        $structure = new Output\Structure();
+        if (array_key_exists($context, $this->chains)) {
+            /* @var Chain $chain */
+            foreach ($this->chains[$context] as $chain) {
+                $chain->output($structure);
+            }
+        }
+
+        return call_user_func($output, $structure);
+    }
+
+    /**
+     * Overwrite the messages for specific keys.
      *
      * @param array $messages
      * @return $this

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -48,13 +48,6 @@ class Validator
     protected $defaultMessages = [];
 
     /**
-     * Contains a Value\Container to keep track of all values we *have* validated.
-     *
-     * @var Container
-     */
-    protected $output;
-
-    /**
      * Contains the name of the current context.
      *
      * @var string
@@ -106,18 +99,18 @@ class Validator
     {
         $isValid = true;
         $messageStack = $this->buildMessageStack($context);
-        $this->output = new Container();
+        $output = new Container();
         $input = new Container($values);
 
         foreach ($this->chains[$context] as $chain) {
             /** @var Chain $chain */
-            $isValid = $chain->validate($messageStack, $input, $this->output) && $isValid;
+            $isValid = $chain->validate($messageStack, $input, $output) && $isValid;
         }
 
         return new ValidationResult(
             $isValid,
             $this->messageStack->getMessages(),
-            $this->output->getArrayCopy()
+            $output->getArrayCopy()
         );
     }
 

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -8,8 +8,6 @@
  */
 namespace Particle\Validator;
 
-use Particle\Validator\Exception\NoSuchContextException;
-use Particle\Validator\Tests\MessageChainTest;
 use Particle\Validator\Value\Container;
 
 class Validator
@@ -29,7 +27,7 @@ class Validator
     ];
 
     /**
-     * Contains an array of contex => MessageStack.
+     * Contains an array of context => MessageStack.
      *
      * @var MessageStack[]
      */
@@ -263,18 +261,12 @@ class Validator
     /**
      * Returns a message stack for the context $context.
      *
-     * @param $context
+     * @param string $context
      * @return MessageStack
      * @throws NoSuchContextException
      */
     protected function getMessageStack($context)
     {
-        if (!array_key_exists($context, $this->messageStacks)) {
-            throw new NoSuchContextException(
-                "Context " . $context . " does not have a message stack"
-            );
-        }
-
         return $this->messageStacks[$context];
     }
 

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -87,11 +87,7 @@ class Validator
         $isValid = true;
         $output = new Container();
         $input = new Container($values);
-        $stack = $this->getMessageStack($context);
-
-        if ($context !== self::DEFAULT_CONTEXT) {
-            $stack->merge($this->getMessageStack(self::DEFAULT_CONTEXT));
-        }
+        $stack = $this->getMergedMessageStack($context);
 
         foreach ($this->chains[$context] as $chain) {
             /** @var Chain $chain */
@@ -263,7 +259,6 @@ class Validator
      *
      * @param string $context
      * @return MessageStack
-     * @throws NoSuchContextException
      */
     protected function getMessageStack($context)
     {
@@ -280,5 +275,23 @@ class Validator
         $messageStack = new MessageStack();
 
         $this->messageStacks[$name] = $messageStack;
+    }
+
+    /**
+     * Returns the message stack. If the context isn't the default context, it will merge the message of the default
+     * context first.
+     *
+     * @param string $context
+     * @return MessageStack
+     */
+    protected function getMergedMessageStack($context)
+    {
+        $stack = $this->getMessageStack($context);
+
+        if ($context !== self::DEFAULT_CONTEXT) {
+            $stack->merge($this->getMessageStack(self::DEFAULT_CONTEXT));
+        }
+
+        return $stack;
     }
 }

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -153,11 +153,13 @@ class Validator
      */
     public function output(callable $output, $context = self::DEFAULT_CONTEXT)
     {
+        $stack = $this->getMessageStack($context);
+
         $structure = new Output\Structure();
         if (array_key_exists($context, $this->chains)) {
             /* @var Chain $chain */
             foreach ($this->chains[$context] as $chain) {
-                $chain->output($structure);
+                $chain->output($structure, $stack);
             }
         }
 

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests;
+namespace Particle\Validator\Tests;
 
 use Particle\Validator\Chain;
 use Particle\Validator\Rule;

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -50,6 +50,7 @@ class ContextTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $result = $this->validator->validate(['first_name' => 'Rick'], 'insert');
+
         $expected = [
             'first_name' => [
                 Rule\Length::TOO_SHORT => 'This is from inside the context.'

--- a/tests/MessageStackTest.php
+++ b/tests/MessageStackTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests;
+namespace Particle\Validator\Tests;
 
 use Particle\Validator\MessageStack;
 

--- a/tests/MessageStackTest.php
+++ b/tests/MessageStackTest.php
@@ -62,13 +62,13 @@ class MessageChainTest extends \PHPUnit_Framework_TestCase
 
         $ms->append('key', 'reason', 'The invisible "default" message. {{key}}', ['key' => 'foo']);
 
-        $this->assertEquals([
+        $expected = [
                 'key' => [
                     'reason' => 'This is my specific message. The key was "foo"',
                 ]
-            ],
-            $ms->getMessages()
-        );
+        ];
+
+        $this->assertEquals($expected, $ms->getMessages());
     }
 
     public function testMergeWillMergeMessagesOfOtherMessageStacks()

--- a/tests/MessageStackTest.php
+++ b/tests/MessageStackTest.php
@@ -2,6 +2,8 @@
 namespace Particle\Validator\Tests;
 
 use Particle\Validator\MessageStack;
+use Particle\Validator\Rule\NotEmpty;
+use Particle\Validator\Rule\Required;
 
 class MessageChainTest extends \PHPUnit_Framework_TestCase
 {
@@ -60,13 +62,42 @@ class MessageChainTest extends \PHPUnit_Framework_TestCase
 
         $ms->append('key', 'reason', 'The invisible "default" message. {{key}}', ['key' => 'foo']);
 
-        $this->assertEquals(
-            [
+        $this->assertEquals([
                 'key' => [
                     'reason' => 'This is my specific message. The key was "foo"',
                 ]
             ],
             $ms->getMessages()
         );
+    }
+
+    public function testMergeWillMergeMessagesOfOtherMessageStacks()
+    {
+        $stack = new MessageStack();
+        $stackTwo = new MessageStack();
+
+        $stack->overwriteMessages([
+            'foo' => [
+                Required::NON_EXISTENT_KEY => 'Non existent key',
+            ]
+        ]);
+
+        $stack->overwriteDefaultMessages([
+            NotEmpty::EMPTY_VALUE => 'Empty value',
+        ]);
+
+        $stackTwo->merge($stack);
+
+        $messages = [
+            $stackTwo->getOverwrite(Required::NON_EXISTENT_KEY, 'foo'),
+            $stackTwo->getOverwrite(NotEmpty::EMPTY_VALUE, 'bar')
+        ];
+
+        $expected = [
+            'Non existent key',
+            'Empty value'
+        ];
+
+        $this->assertEquals($expected, $messages);
     }
 }

--- a/tests/MessageStackTest.php
+++ b/tests/MessageStackTest.php
@@ -63,9 +63,9 @@ class MessageChainTest extends \PHPUnit_Framework_TestCase
         $ms->append('key', 'reason', 'The invisible "default" message. {{key}}', ['key' => 'foo']);
 
         $expected = [
-                'key' => [
-                    'reason' => 'This is my specific message. The key was "foo"',
-                ]
+            'key' => [
+                'reason' => 'This is my specific message. The key was "foo"',
+            ]
         ];
 
         $this->assertEquals($expected, $ms->getMessages());

--- a/tests/Rule/AlnumTest.php
+++ b/tests/Rule/AlnumTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Rule;
+namespace Particle\Validator\Tests\Rule;
 
 use Particle\Validator\Rule\Alnum;
 use Particle\Validator\Validator;

--- a/tests/Rule/AlphaTest.php
+++ b/tests/Rule/AlphaTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Rule;
+namespace Particle\Validator\Tests\Rule;
 
 use Particle\Validator\Rule\Alpha;
 use Particle\Validator\Validator;

--- a/tests/Rule/BetweenTest.php
+++ b/tests/Rule/BetweenTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Rule;
+namespace Particle\Validator\Tests\Rule;
 
 use Particle\Validator\Rule\Between;
 use Particle\Validator\Validator;

--- a/tests/Rule/BooleanTest.php
+++ b/tests/Rule/BooleanTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Rule;
+namespace Particle\Validator\Tests\Rule;
 
 use Particle\Validator\Rule\Boolean;
 use Particle\Validator\Validator;

--- a/tests/Rule/CallbackTest.php
+++ b/tests/Rule/CallbackTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Rule;
+namespace Particle\Validator\Tests\Rule;
 
 use Particle\Validator\Exception\InvalidValueException;
 use Particle\Validator\Rule\Callback;

--- a/tests/Rule/DatetimeTest.php
+++ b/tests/Rule/DatetimeTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Rule;
+namespace Particle\Validator\Tests\Rule;
 
 use Particle\Validator\Validator;
 use \DateTime;

--- a/tests/Rule/DigitsTest.php
+++ b/tests/Rule/DigitsTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Rule;
+namespace Particle\Validator\Tests\Rule;
 
 use Particle\Validator\Rule\Digits;
 use Particle\Validator\Validator;

--- a/tests/Rule/EmailTest.php
+++ b/tests/Rule/EmailTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Rule;
+namespace Particle\Validator\Tests\Rule;
 
 use Particle\Validator\Rule\Digits;
 use Particle\Validator\Rule\Email;

--- a/tests/Rule/EqualTest.php
+++ b/tests/Rule/EqualTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Rule;
+namespace Particle\Validator\Tests\Rule;
 
 use Particle\Validator\Rule\Equal;
 use Particle\Validator\Validator;

--- a/tests/Rule/GreaterThanTest.php
+++ b/tests/Rule/GreaterThanTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Rule;
+namespace Particle\Validator\Tests\Rule;
 
 use Particle\Validator\Rule\GreaterThan;
 use Particle\Validator\Validator;

--- a/tests/Rule/InArrayTest.php
+++ b/tests/Rule/InArrayTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Rule;
+namespace Particle\Validator\Tests\Rule;
 
 use Particle\Validator\Rule\InArray;
 use Particle\Validator\Validator;

--- a/tests/Rule/IntegerTest.php
+++ b/tests/Rule/IntegerTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Rule;
+namespace Particle\Validator\Tests\Rule;
 
 use Particle\Validator\Rule\Integer;
 use Particle\Validator\Validator;

--- a/tests/Rule/LengthBetweenTest.php
+++ b/tests/Rule/LengthBetweenTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Rule;
+namespace Particle\Validator\Tests\Rule;
 
 use Particle\Validator\Rule\LengthBetween;
 use Particle\Validator\Validator;

--- a/tests/Rule/LengthTest.php
+++ b/tests/Rule/LengthTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Rule;
+namespace Particle\Validator\Tests\Rule;
 
 use Particle\Validator\Rule\Length;
 use Particle\Validator\Validator;

--- a/tests/Rule/LessThanTest.php
+++ b/tests/Rule/LessThanTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Rule;
+namespace Particle\Validator\Tests\Rule;
 
 use Particle\Validator\Rule\LessThan;
 use Particle\Validator\Validator;

--- a/tests/Rule/NotEmptyTest.php
+++ b/tests/Rule/NotEmptyTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Rule;
+namespace Particle\Validator\Tests\Rule;
 
 use Particle\Validator\Rule\NotEmpty;
 use Particle\Validator\Rule\Required;

--- a/tests/Rule/NumericTest.php
+++ b/tests/Rule/NumericTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Rule;
+namespace Particle\Validator\Tests\Rule;
 
 use Particle\Validator\Rule\Numeric;
 use Particle\Validator\Validator;

--- a/tests/Rule/RegexTest.php
+++ b/tests/Rule/RegexTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Rule;
+namespace Particle\Validator\Tests\Rule;
 
 use Particle\Validator\Rule\Regex;
 use Particle\Validator\Validator;

--- a/tests/Rule/RequiredTest.php
+++ b/tests/Rule/RequiredTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Rule;
+namespace Particle\Validator\Tests\Rule;
 
 use Particle\Validator\Rule\Required;
 use Particle\Validator\Validator;

--- a/tests/Rule/UrlTest.php
+++ b/tests/Rule/UrlTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Rule;
+namespace Particle\Validator\Tests\Rule;
 
 use Particle\Validator\Rule\Url;
 use Particle\Validator\Validator;

--- a/tests/Rule/UuidTest.php
+++ b/tests/Rule/UuidTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests\Rule;
+namespace Particle\Validator\Tests\Rule;
 
 use Particle\Validator\Validator;
 use Particle\Validator\Rule\Uuid;

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests;
+namespace Particle\Validator\Tests;
 
 use Particle\Validator\Rule;
 use Particle\Validator\Value\Container;

--- a/tests/Support/Statement.php
+++ b/tests/Support/Statement.php
@@ -1,0 +1,41 @@
+<?php
+namespace Particle\Validator\Tests\Support;
+
+class Statement
+{
+    /**
+     * @var string
+     */
+    protected $statement;
+
+    /**
+     * @var bool
+     */
+    protected $result;
+
+    /**
+     * @param string $statement
+     * @param bool $result
+     */
+    public function __construct($statement, $result)
+    {
+        $this->statement = $statement;
+        $this->result = $result;
+    }
+
+    /**
+     * @return bool
+     */
+    public function __invoke()
+    {
+        return $this->result;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->statement;
+    }
+}

--- a/tests/ValidationResultTest.php
+++ b/tests/ValidationResultTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Particle\Tests;
+namespace Particle\Validator\Tests;
 
 use Particle\Validator\ValidationResult;
 use Particle\Validator\Rule\Alpha;

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -3,6 +3,8 @@ namespace Particle\Validator\Tests;
 
 use Particle\Validator\Output\Structure;
 use Particle\Validator\Rule;
+use Particle\Validator\Rule\Email;
+use Particle\Validator\Rule\LengthBetween;
 use Particle\Validator\Tests\Support\Statement;
 use Particle\Validator\Validator;
 use Particle\Validator\Rule\Required;
@@ -204,6 +206,16 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
             return $output;
         };
 
+        $this->validator->overwriteDefaultMessages([
+            LengthBetween::TOO_LONG => 'This is too long to output!'
+        ]);
+
+        $this->validator->overwriteMessages([
+            'email' => [
+                Email::INVALID_FORMAT => 'This is not a valid email address',
+            ]
+        ]);
+
         $this->validator->required('email')->email();
         $this->validator->optional('firstname')->allowEmpty(true)->lengthBetween(0, 20);
 
@@ -238,7 +250,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 [
                     'rule' => 'Email',
                     'messages' => [
-                        Rule\Email::INVALID_FORMAT => '{{ name }} must be a valid email address',
+                        Rule\Email::INVALID_FORMAT => 'This is not a valid email address',
                     ],
                     'parameters' => [
                         'key' => 'email',
@@ -274,7 +286,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 [
                     'rule' => 'LengthBetween',
                     'messages' => [
-                        'LengthBetween::TOO_LONG' => '{{ name }} must be shorter than {{ max }} characters',
+                        LengthBetween::TOO_LONG => 'This is too long to output!',
                         'LengthBetween::TOO_SHORT' => '{{ name }} must be longer than {{ min }} characters',
                     ],
                     'parameters' => [

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -1,7 +1,9 @@
 <?php
-namespace Particle\Tests;
+namespace Particle\Validator\Tests;
 
+use Particle\Validator\Output\Structure;
 use Particle\Validator\Rule;
+use Particle\Validator\Tests\Support\Statement;
 use Particle\Validator\Validator;
 use Particle\Validator\Rule\Required;
 
@@ -182,5 +184,127 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
     public function testUnconfiguredValidatorWillNotShowNotice()
     {
         $this->assertTrue($this->validator->validate(['value' => 'yes'])->isValid());
+    }
+
+    public function testOutputWillGiveRepresentationOfInternalStructure()
+    {
+        $callable = function (Structure $structure) {
+            $output = [];
+            $subjects = $structure->getSubjects();
+            foreach ($subjects as $subject) {
+                foreach ($subject->getRules() as $rule) {
+                    $output[$subject->getKey()][] = [
+                        'rule' => $rule->getName(),
+                        'messages' => $rule->getMessages(),
+                        'parameters' => $rule->getParameters(),
+                    ];
+                }
+            }
+
+            return $output;
+        };
+
+        $this->validator->required('email')->email();
+        $this->validator->optional('firstname')->allowEmpty(true)->lengthBetween(0, 20);
+
+        $definition = $this->validator->output($callable);
+
+        $expected = [
+            'email' => [
+                [
+                    'rule' => 'Required',
+                    'messages' => [
+                        Required::NON_EXISTENT_KEY => '{{ key }} must be provided, but does not exist',
+                    ],
+                    'parameters' => [
+                        'key' => 'email',
+                        'name' => 'email',
+                        'required' => true,
+                        'callback' => null,
+                    ]
+                ],
+                [
+                    'rule' => 'NotEmpty',
+                    'messages' => [
+                        Rule\NotEmpty::EMPTY_VALUE => '{{ name }} must not be empty',
+                    ],
+                    'parameters' => [
+                        'key' => 'email',
+                        'name' => 'email',
+                        'allowEmpty' => false,
+                        'callback' => null,
+                    ]
+                ],
+                [
+                    'rule' => 'Email',
+                    'messages' => [
+                        Rule\Email::INVALID_FORMAT => '{{ name }} must be a valid email address',
+                    ],
+                    'parameters' => [
+                        'key' => 'email',
+                        'name' => 'email',
+                    ]
+                 ]
+            ],
+            'firstname' => [
+                [
+                    'rule' => 'Required',
+                    'messages' => [
+                        Required::NON_EXISTENT_KEY => '{{ key }} must be provided, but does not exist',
+                    ],
+                    'parameters' => [
+                        'key' => 'firstname',
+                        'name' => 'firstname',
+                        'required' => false,
+                        'callback' => null,
+                    ],
+                ],
+                [
+                    'rule' => 'NotEmpty',
+                    'messages' => [
+                        Rule\NotEmpty::EMPTY_VALUE => '{{ name }} must not be empty',
+                    ],
+                    'parameters' => [
+                        'key' => 'firstname',
+                        'name' => 'firstname',
+                        'allowEmpty' => true,
+                        'callback' => null,
+                    ],
+                ],
+                [
+                    'rule' => 'LengthBetween',
+                    'messages' => [
+                        'LengthBetween::TOO_LONG' => '{{ name }} must be shorter than {{ max }} characters',
+                        'LengthBetween::TOO_SHORT' => '{{ name }} must be longer than {{ min }} characters',
+                    ],
+                    'parameters' => [
+                        'key' => 'firstname',
+                        'name' => 'firstname',
+                        'min' => 0,
+                        'max' => 20,
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $definition);
+    }
+
+    public function testOutputWillGiveStatementIfItImplementsToString()
+    {
+        $this->validator->required('foo')
+            ->required(new Statement('is required', false))
+            ->allowEmpty(new Statement('is empty allowed', false))
+            ->callback(new Statement('callback content', false));
+
+        $callback = function (Structure $structure) {
+            $rules = $structure->getSubjects()[0]->getRules();
+
+            $this->assertEquals('is required', $rules[0]->getParameters()['callback']);
+            $this->assertEquals('is empty allowed', $rules[1]->getParameters()['callback']);
+            $this->assertEquals('callback content', $rules[2]->getParameters()['callback']);
+        };
+
+        $this->validator->output($callback);
     }
 }


### PR DESCRIPTION
## What?

Adding functionality to output a representation of the internal structure of the validator. This is done by passing a `Structure` object to a callback. That callback is then responsible for rendering to an output format. The `Structure` object contains `Subject` objects (which are representation of the `Chain`), and that in turn contains `Rule` objects, which represent... well, rules.

Because of the separation of the `Structure` object from the actual internal structure, we can freely refactor later without breaking existing renderers.

Also, I've implemented an additional "parameter" for the `Required`, `NotEmpty` and `Callback` rules. This is awesome, because we could mix the Symfony Expression Language component with Particle\Validator to create callbacks which are parsable by PHP, but also by other languages, provided they can also parse the same statements.

This PR supersedes PR #81. 

## How to test

Well, check the tests. :)

## To do?

 - [x] Write documentation on output and on how one can combine it with the Symfony Expression Language component.
 - [x] Make sure overwritten messages are displayed correctly on output.