### PR TITLE
Fixed UUIDv4 validation

### DIFF
--- a/src/Rule/Uuid.php
+++ b/src/Rule/Uuid.php
@@ -33,7 +33,7 @@ class Uuid extends Regex
      * @var array
      */
     protected $regexes = [
-        4 => '~[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}~i',
+        4 => '~[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}~i',      // UUIDv4 Format
     ];
 
     /**

--- a/tests/Rule/UuidTest.php
+++ b/tests/Rule/UuidTest.php
@@ -16,18 +16,45 @@ class UuidV4Test extends \PHPUnit_Framework_TestCase
         $this->validator = new Validator();
     }
 
-    public function testReturnsTrueWhenMatchesUuidV4()
+    public function correctUUIDv4()
+    {
+        return array(
+            array('44c0ffee-988a-49dc-8bad-a55c0de2d1e4'),
+            array('de305d54-75b4-431b-adb2-eb6b9e546014'),
+            array('00000000-0000-4000-8000-000000000000'),
+        );
+    }
+
+    public function incorrectUUIDv4()
+    {
+        return array(
+            array('xxc0ffee-988a-49dc-8bad-a55c0de2d1e4'),
+            array('123e4567-e89b-12d3-a456-426655440000'),
+            array('00000000-0000-0000-0000-000000000000'),      // NIL uuid
+            array('a8098c1a-f86e-11da-bd1a-00112444be1e'),      // UUIDv1
+            array('6fa459ea-ee8a-3ca4-894e-db77e160355e'),      // UUIDv3
+            array('886313e1-3b8a-5372-9b90-0c9aee199e5d'),      // UUIDv4
+        );
+    }
+
+    /**
+     * @dataProvider correctUUIDv4
+     */
+    public function testReturnsTrueWhenMatchesUuidV4($uuid)
     {
         $this->validator->required('guid')->uuid();
-        $result = $this->validator->validate(['guid' => '44c0ffee-988a-49dc-0bad-a55c0de2d1e4']);
+        $result = $this->validator->validate(['guid' => $uuid]);
         $this->assertTrue($result->isValid());
         $this->assertEquals([], $result->getMessages());
     }
 
-    public function testReturnsFalseOnNoMatch()
+    /**
+     * @dataProvider incorrectUUIDv4
+     */
+    public function testReturnsFalseOnNoMatch($uuid)
     {
         $this->validator->required('guid')->uuid();
-        $result = $this->validator->validate(['guid' => 'xxc0ffee-988a-49dc-0bad-a55c0de2d1e4']);
+        $result = $this->validator->validate(['guid' => $uuid]);
         $this->assertFalse($result->isValid());
 
         $expected = [


### PR DESCRIPTION
UUIDv4 have a specific format where certain bits are not random but must have specified bits set. This has been fixed in this PR.