### PR TITLE
Fixing an issue where an integer timestamp is not validated as a valid timestamp

### DIFF
--- a/src/Rule/Datetime.php
+++ b/src/Rule/Datetime.php
@@ -90,7 +90,9 @@ class Datetime extends Rule
      */
     protected function checkDate($dateTime, $format, $value)
     {
-        if ($dateTime->getLastErrors()['warning_count'] === 0 && $dateTime->format($format) === $value) {
+        $equal = (string) $dateTime->format($format) === (string) $value;
+
+        if ($dateTime->getLastErrors()['warning_count'] === 0 && $equal) {
             return $dateTime;
         }
         return false;

--- a/tests/Rule/DatetimeTest.php
+++ b/tests/Rule/DatetimeTest.php
@@ -101,6 +101,16 @@ class DatetimeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $this->validator->getMessages());
     }
 
+    public function testCheckForValidDateWillAcceptBothStringsAsIntegers()
+    {
+        $this->validator->required('timestamp')->datetime('U');
+        $result = $this->validator->validate([
+            'timestamp' => (int) (new \DateTime())->format('U'),
+        ]);
+
+        $this->assertTrue($result);
+    }
+
     public function getMessage($reason)
     {
         $messages = [


### PR DESCRIPTION
## What

Thanks to @renatomefidf, a bug was discovered in which a valid time stamp was not validated by datetime. This is because of strict checking, which should not happen.

## How to test

Check the unit tests for proof that it now works correctly :)