### PR TITLE
Adding test for mailto: support.

### DIFF
--- a/tests/Rule/UrlTest.php
+++ b/tests/Rule/UrlTest.php
@@ -74,6 +74,17 @@ class UrlTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testSucceedsOnAlternativeWhiteListedScheme()
+    {
+        $this->validator->required('url')->url(['mailto']);
+
+        $this->assertTrue(
+            $this->validator->validate([
+                'url' => 'mailto:robbie@example.org',
+            ])
+        );
+    }
+
     public function getValidUrls()
     {
         return [


### PR DESCRIPTION
## What

As indicated @robquistnl, the mailto is a strange sort of URL, in that it doesn't contain the double slash, so we should probably add a test case for this. This PR introduces that.