### PR TITLE
Adding test for mailto: support into master

### DIFF
--- a/tests/Rule/UrlTest.php
+++ b/tests/Rule/UrlTest.php
@@ -50,11 +50,11 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     {
         $this->validator->required('url')->url(['http', 'https']);
 
-        $this->assertFalse(
-            $this->validator->validate([
-                'url' => 'git://github.com'
-            ])
-        );
+        $result = $this->validator->validate([
+            'url' => 'git://github.com'
+        ]);
+
+        $this->assertFalse($result->isValid());
 
         $expected = [
             'url' => [
@@ -62,18 +62,18 @@ class UrlTest extends \PHPUnit_Framework_TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $this->validator->getMessages());
+        $this->assertEquals($expected, $result->getMessages());
     }
 
     public function testSucceedsOnWhiteListedScheme()
     {
         $this->validator->required('url')->url(['http', 'https']);
 
-        $this->assertTrue(
-            $this->validator->validate([
-                'url' => 'http://github.com',
-            ])
-        );
+        $result = $this->validator->validate([
+            'url' => 'http://github.com',
+        ]);
+
+        $this->assertTrue($result->isValid());
     }
 
     public function getValidUrls()

--- a/tests/Rule/UrlTest.php
+++ b/tests/Rule/UrlTest.php
@@ -80,11 +80,11 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     {
         $this->validator->required('url')->url(['mailto']);
 
-        $this->assertTrue(
-            $this->validator->validate([
-                'url' => 'mailto:robbie@example.org',
-            ])
-        );
+        $result = $this->validator->validate([
+            'url' => 'mailto:robbie@example.org',
+        ]);
+
+        $this->assertTrue($result->isValid());
     }
 
     public function getValidUrls()


### PR DESCRIPTION
## What

v1.0 now contains an extra test for supporting `mailto:`, which I want to have in master too.