### PR TITLE
Fixes overwriting output values with dot notation

### DIFF
--- a/src/Value/Container.php
+++ b/src/Value/Container.php
@@ -112,7 +112,7 @@ class Container
         $ref = &$this->values;
 
         foreach ($parts as $i => $part) {
-            if ($i < count($parts) - 1) {
+            if ($i < count($parts) - 1 && (!isset($ref[$part]) || !is_array($ref[$part]))) {
                 $ref[$part] = [];
             }
             $ref = &$ref[$part];

--- a/tests/Value/ContainerTest.php
+++ b/tests/Value/ContainerTest.php
@@ -1,0 +1,67 @@
+<?php
+namespace Particle\Validator\Tests\Value;
+
+use Particle\Validator\Value\Container;
+
+class ValidatorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Container
+     */
+    protected $container;
+
+    public function setUp()
+    {
+        $this->container = new Container();
+    }
+
+    public function testSet()
+    {
+        $setters = [
+            'id' => 8,
+            'data' => 42,
+            'name' => 'Eight',
+            'point' => 'None',
+        ];
+
+        $expected = [
+            'id' => 8,
+            'data' => 42,
+            'name' => 'Eight',
+            'point' => 'None',
+        ];
+
+        foreach ($setters as $key => $value) {
+            $this->container->set($key, $value);
+        }
+
+        $this->assertSame($expected, $this->container->getArrayCopy());
+    }
+
+    public function testSetTraverse()
+    {
+        $setters = [
+            'test.sub.id' => 8,
+            'test.data' => 42,
+            'test.sub.name' => 'Eight',
+            'test.sub.point' => 'None',
+        ];
+
+        $expected = [
+            'test' => [
+                'sub' => [
+                    'id' => 8,
+                    'name' => 'Eight',
+                    'point' => 'None',
+                ],
+                'data' => 42,
+            ],
+        ];
+
+        foreach ($setters as $key => $value) {
+            $this->container->set($key, $value);
+        }
+
+        $this->assertSame($expected, $this->container->getArrayCopy());
+    }
+}


### PR DESCRIPTION
When using multiple dot notations, for example to validate a JSON-API input object:

    { "data": { "type": "pages", "attributes": { "title": "Example Page", "slug": "example-page" } } }

And validating this:

```
$validator = new Validator();
$validator->required('data.type')->equals('pages');
$validator->required('data.attributes.title')->lengthBetween(1, 512);
$validator->required('data.attributes.slug')->lengthBetween(1, 48)->regex('#^[a-z0-9\-]+$#');
$validationResult = $validator->validate($data);
if ($validationResult->isNotValid()) {
    throw new \Exception;
}
var_dump($validationResult->getValues());
```

Will result in:
```
array(1) {
  ["data"]=>
    array(1) {
      ["attributes"] =>
        array(1) {
          ["slug"] =>
            string(12) "example-page"
        }
    }
}
```

Because the old code traversed without checking if the key already existed and had contents. Thus only the last value of the toplevel "data" survives as each time the toplevel "data" array got overwritten with a new empty array.