### PR TITLE
traverse() doesn't do what its docs say it does

### DIFF
--- a/src/Value/Container.php
+++ b/src/Value/Container.php
@@ -92,7 +92,7 @@ class Container
         $value = $this->values;
         foreach (explode('.', $key) as $part) {
             if (!array_key_exists($part, $value)) {
-                return false;
+                return $returnValue ? null : false;
             }
             $value = $value[$part];
         }


### PR DESCRIPTION
The traverse() function is documented to return either the value or null, unless its `$returnValue` flag is set to false. But currently it will return false when the value doesn't exist, which is wrong. A non-existent value should either error or return null, but not return a valid value such as `false` which may well be a meaningful value.