### PR TITLE
Only existing input in ValidationResult values

### DIFF
--- a/src/Chain.php
+++ b/src/Chain.php
@@ -367,8 +367,6 @@ class Chain
     public function validate(MessageStack $messageStack, Container $input, Container $output)
     {
         $valid = true;
-        $output->set($this->key, $input->get($this->key));
-
         foreach ($this->rules as $rule) {
             $rule->setMessageStack($messageStack);
             $rule->setParameters($this->key, $this->name);
@@ -376,8 +374,12 @@ class Chain
             $valid = $rule->isValid($this->key, $input) && $valid;
 
             if ($rule->shouldBreakChain()) {
-                return $valid;
+                break;
             }
+        }
+
+        if ($valid && $input->has($this->key)) {
+            $output->set($this->key, $input->get($this->key));
         }
         return $valid;
     }

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -97,12 +97,35 @@ class Validator
         $result = new ValidationResult(
             $isValid,
             $stack->getFailures(),
-            $output->getArrayCopy()
+            $this->filterResultByExistingInput($output->getArrayCopy(), $input->getArrayCopy())
         );
 
         $stack->reset();
 
         return $result;
+    }
+
+    /**
+     * Walks through the output recursively to check if all its values exist in the input.
+     * Only keys that are part of the input should be visible as output.
+     *
+     * @param array $output
+     * @param array $input
+     * @return array
+     */
+    private function filterResultByExistingInput(array $output, array $input)
+    {
+        foreach ($output as $key => $value) {
+            if (!array_key_exists($key, $input)) {
+                unset($output[$key]);
+                continue;
+            }
+            if (is_array($value) && is_array($input[$key])) {
+                $output[$key] = $this->filterResultByExistingInput($output[$key], $input[$key]);
+            }
+        }
+
+        return $output;
     }
 
     /**

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -97,35 +97,12 @@ class Validator
         $result = new ValidationResult(
             $isValid,
             $stack->getFailures(),
-            $this->filterResultByExistingInput($output->getArrayCopy(), $input->getArrayCopy())
+            $output->getArrayCopy()
         );
 
         $stack->reset();
 
         return $result;
-    }
-
-    /**
-     * Walks through the output recursively to check if all its values exist in the input.
-     * Only keys that are part of the input should be visible as output.
-     *
-     * @param array $output
-     * @param array $input
-     * @return array
-     */
-    private function filterResultByExistingInput(array $output, array $input)
-    {
-        foreach ($output as $key => $value) {
-            if (!array_key_exists($key, $input)) {
-                unset($output[$key]);
-                continue;
-            }
-            if (is_array($value) && is_array($input[$key])) {
-                $output[$key] = $this->filterResultByExistingInput($output[$key], $input[$key]);
-            }
-        }
-
-        return $output;
     }
 
     /**

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -99,11 +99,36 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
     {
         $this->validator->required('first_name')->lengthBetween(2, 20);
         $this->validator->required('last_name')->lengthBetween(2, 60);
+        $this->validator->optional('age')->between(18, 100);
 
         $result = $this->validator->validate([
             'first_name' => 'Berry',
             'last_name' => 'Langerak',
-            'is_admin' => true
+            'is_admin' => true,
+            'age' => 42,
+        ]);
+
+        $expected = [
+            'first_name' => 'Berry',
+            'last_name' => 'Langerak',
+            'age' => 42,
+        ];
+
+        $this->assertEquals($expected, $result->getValues());
+    }
+
+    public function testDoesNotReturnInvalidValues()
+    {
+        $this->validator->required('first_name')->lengthBetween(2, 20);
+        $this->validator->required('last_name')->lengthBetween(2, 60);
+        $this->validator->optional('age')->between(18, 100);
+        $this->validator->optional('date')->datetime('Y-m-d');
+
+        $result = $this->validator->validate([
+            'first_name' => 'Berry',
+            'last_name' => 'Langerak',
+            'is_admin' => true,
+            'date' => '01/01/1970',
         ]);
 
         $expected = [


### PR DESCRIPTION
Currently the ValidationResult::getValues() will return both values that were part of the input and values that weren't. Optional values will currently get `false` as filling, or `null` after my other pull-request. This means that optional values are filled by validation and returned as validated values, while the given validated values are not validated at all and basicly faked. This change aims to leave out optional values.

To go over the current options, and why this change is proposed:

**Current: fill optional empty fields with false**
This is wrong, `false` may be a perfectly valid value and thus gets a double meaning. Where it being left out (validly as it is optional) returns it as set to false. This ambiguity is very dangerous.

**Alternatively after my pull request for Container::traverse()**
This makes it filled with `null`. While `null` would be valid in the sense that it denotes an empty field, it does pose other problems. For example, a database field might be either empty (`null`) or have a valid value (non-`null`). If `null` becomes the default value I can't distinguish if it was left empty because of a partial update or intentionally emptied to become `null`.

**Leave out non-existent fields from validation result**
This is what this PR proposed. Any fields not part of the input should not be in the ValidationResult. They are either optional and thus validly not part of the output. Or they are required, didn't validate and shouldn't be in the getValues() output.