### PR TITLE
Fix faulty docblock

### DIFF
--- a/src/Chain.php
+++ b/src/Chain.php
@@ -156,7 +156,7 @@ class Chain
      * Validates a value to be a nested array, which can then be validated using a new Validator instance.
      *
      * @param callable $callback
-     * @return Chain
+     * @return $this
      */
     public function each(callable $callback)
     {

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -257,7 +257,7 @@ class Chain
      * Mount a rule object onto this chain.
      *
      * @param Rule $rule
-     * @return Chain
+     * @return $this
      */
     public function mount(Rule $rule)
     {
@@ -300,7 +300,7 @@ class Chain
      * Validates that the value is a valid UUID
      *
      * @param int $version
-     * @return Chain
+     * @return $this
      */
     public function uuid($version = Rule\Uuid::UUID_V4)
     {


### PR DESCRIPTION
### What

When chaining validators form an extended validator, $this should be returned in the phpdoc to support auto-completion