### PR TITLE
Changed error messages for lengthBetween rule to indicate min and max values are inclusive.

### DIFF
--- a/src/Rule/LengthBetween.php
+++ b/src/Rule/LengthBetween.php
@@ -33,8 +33,8 @@ class LengthBetween extends Between
      * @var array
      */
     protected $messageTemplates = [
-        self::TOO_LONG => '{{ name }} must be shorter than {{ max }} characters',
-        self::TOO_SHORT => '{{ name }} must be longer than {{ min }} characters'
+        self::TOO_LONG => '{{ name }} must be {{ max }} characters or shorter',
+        self::TOO_SHORT => '{{ name }} must be {{ min }} characters or longer'
     ];
 
     /**

--- a/tests/Rule/LengthBetweenTest.php
+++ b/tests/Rule/LengthBetweenTest.php
@@ -64,8 +64,8 @@ class LengthBetweenTest extends \PHPUnit_Framework_TestCase
     public function getMessage($reason)
     {
         $messages = [
-            LengthBetween::TOO_SHORT => 'first name must be longer than 3 characters',
-            LengthBetween::TOO_LONG => 'first name must be shorter than 6 characters',
+            LengthBetween::TOO_SHORT => 'first name must be 3 characters or longer',
+            LengthBetween::TOO_LONG => 'first name must be 6 characters or shorter',
         ];
 
         return $messages[$reason];

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -287,7 +287,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                     'rule' => 'LengthBetween',
                     'messages' => [
                         LengthBetween::TOO_LONG => 'This is too long to output!',
-                        'LengthBetween::TOO_SHORT' => '{{ name }} must be longer than {{ min }} characters',
+                        'LengthBetween::TOO_SHORT' => '{{ name }} must be {{ min }} characters or longer',
                     ],
                     'parameters' => [
                         'key' => 'firstname',


### PR DESCRIPTION
The lengthBetween rule treats the min and max parameters as inclusive values.  However, the current error messages exclude those values.
For example, this rule:  $this->validator->required('firstname')->lengthBetween(2, 7);
Can produce these error messages:
"firstname must be shorter than 7 characters"
"firstname must be longer than 2 characters"

The updated error messages are:
"firstname must be 7 characters or shorter"
"firstname must be 2 characters or longer"