### PR TITLE
Fix: Remove unused imports

### DIFF
--- a/tests/ChainTest.php
+++ b/tests/ChainTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace Particle\Validator\Tests;
 
-use Particle\Validator\Rule;
 use Particle\Validator\Tests\Support\CustomRule;
 use Particle\Validator\Validator;
 

--- a/tests/Rule/EmailTest.php
+++ b/tests/Rule/EmailTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace Particle\Validator\Tests\Rule;
 
-use Particle\Validator\Rule\Digits;
 use Particle\Validator\Rule\Email;
 use Particle\Validator\Validator;
 


### PR DESCRIPTION
This PR

* [x] removes unused imports

💁 Ran

```
$ composer global require fabpot/php-cs-fixer:2.0.0-alpha && php-cs-fixer fix --rules=no_unused_imports --using-cache=no .
```