### PR TITLE
Fix: Reduce visibility of setUp()

### DIFF
--- a/tests/ChainTest.php
+++ b/tests/ChainTest.php
@@ -11,7 +11,7 @@ class ChainTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new Validator();
     }

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -12,7 +12,7 @@ class ContextTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new Validator();
     }

--- a/tests/Rule/AlnumTest.php
+++ b/tests/Rule/AlnumTest.php
@@ -11,7 +11,7 @@ class AlnumTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new Validator();
     }

--- a/tests/Rule/AlphaTest.php
+++ b/tests/Rule/AlphaTest.php
@@ -11,7 +11,7 @@ class AlphaTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new Validator();
     }

--- a/tests/Rule/BetweenTest.php
+++ b/tests/Rule/BetweenTest.php
@@ -11,7 +11,7 @@ class BetweenTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new Validator();
     }

--- a/tests/Rule/BooleanTest.php
+++ b/tests/Rule/BooleanTest.php
@@ -11,7 +11,7 @@ class BooleanTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new Validator();
     }

--- a/tests/Rule/CallbackTest.php
+++ b/tests/Rule/CallbackTest.php
@@ -12,7 +12,7 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new Validator();
     }

--- a/tests/Rule/CreditCardTest.php
+++ b/tests/Rule/CreditCardTest.php
@@ -11,7 +11,7 @@ class CreditCardTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new Validator();
     }

--- a/tests/Rule/DatetimeTest.php
+++ b/tests/Rule/DatetimeTest.php
@@ -11,7 +11,7 @@ class DatetimeTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new Validator();
     }

--- a/tests/Rule/DigitsTest.php
+++ b/tests/Rule/DigitsTest.php
@@ -11,7 +11,7 @@ class DigitsTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new Validator();
     }

--- a/tests/Rule/EachTest.php
+++ b/tests/Rule/EachTest.php
@@ -13,7 +13,7 @@ class EachTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new Validator();
     }

--- a/tests/Rule/EmailTest.php
+++ b/tests/Rule/EmailTest.php
@@ -11,7 +11,7 @@ class EmailTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new Validator();
     }

--- a/tests/Rule/EqualTest.php
+++ b/tests/Rule/EqualTest.php
@@ -11,7 +11,7 @@ class EqualTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new Validator();
     }

--- a/tests/Rule/GreaterThanTest.php
+++ b/tests/Rule/GreaterThanTest.php
@@ -11,7 +11,7 @@ class GreaterThanTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new Validator();
     }

--- a/tests/Rule/InArrayTest.php
+++ b/tests/Rule/InArrayTest.php
@@ -11,7 +11,7 @@ class InArrayTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new Validator();
     }

--- a/tests/Rule/IntegerTest.php
+++ b/tests/Rule/IntegerTest.php
@@ -11,7 +11,7 @@ class IntegerTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new Validator();
     }

--- a/tests/Rule/IsArrayTest.php
+++ b/tests/Rule/IsArrayTest.php
@@ -12,7 +12,7 @@ class IsArrayTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new Validator();
     }

--- a/tests/Rule/JsonTest.php
+++ b/tests/Rule/JsonTest.php
@@ -11,7 +11,7 @@ class JsonTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new Validator();
     }

--- a/tests/Rule/LengthBetweenTest.php
+++ b/tests/Rule/LengthBetweenTest.php
@@ -11,7 +11,7 @@ class LengthBetweenTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new Validator();
     }

--- a/tests/Rule/LengthTest.php
+++ b/tests/Rule/LengthTest.php
@@ -11,7 +11,7 @@ class LengthTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new Validator();
     }

--- a/tests/Rule/LessThanTest.php
+++ b/tests/Rule/LessThanTest.php
@@ -11,7 +11,7 @@ class LessThanTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new Validator();
     }

--- a/tests/Rule/NotEmptyTest.php
+++ b/tests/Rule/NotEmptyTest.php
@@ -11,7 +11,7 @@ class NotEmptyTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new Validator();
     }

--- a/tests/Rule/NumericTest.php
+++ b/tests/Rule/NumericTest.php
@@ -11,7 +11,7 @@ class NumericTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new Validator();
     }

--- a/tests/Rule/PhoneTest.php
+++ b/tests/Rule/PhoneTest.php
@@ -11,7 +11,7 @@ class PhoneTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new Validator();
     }

--- a/tests/Rule/RegexTest.php
+++ b/tests/Rule/RegexTest.php
@@ -11,7 +11,7 @@ class RegexTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new Validator();
     }

--- a/tests/Rule/RequiredTest.php
+++ b/tests/Rule/RequiredTest.php
@@ -11,7 +11,7 @@ class RequiredTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new Validator();
     }

--- a/tests/Rule/UrlTest.php
+++ b/tests/Rule/UrlTest.php
@@ -11,7 +11,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new Validator();
     }

--- a/tests/Rule/UuidTest.php
+++ b/tests/Rule/UuidTest.php
@@ -11,7 +11,7 @@ class UuidV4Test extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new Validator();
     }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -16,7 +16,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new Validator();
     }

--- a/tests/Value/ContainerTest.php
+++ b/tests/Value/ContainerTest.php
@@ -10,7 +10,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
      */
     protected $container;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->container = new Container();
     }


### PR DESCRIPTION
This PR

* [x] reduces the visibility of `setUp()` from `public` to `protected`

💁 This is the visibility as defined on the parent, there's no need to increase it.