### PR TITLE
Fix: Reduce visibility of getMessage()

### DIFF
--- a/tests/Rule/AlnumTest.php
+++ b/tests/Rule/AlnumTest.php
@@ -93,7 +93,7 @@ class AlnumTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
-    public function getMessage($reason)
+    private function getMessage($reason)
     {
         $messages = [
             Alnum::NOT_ALNUM => 'first name may only consist out of numeric and alphabetic characters'

--- a/tests/Rule/AlphaTest.php
+++ b/tests/Rule/AlphaTest.php
@@ -93,7 +93,7 @@ class AlphaTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
-    public function getMessage($reason)
+    private function getMessage($reason)
     {
         $messages = [
             Alpha::NOT_ALPHA => 'first name may only consist out of alphabetic characters',

--- a/tests/Rule/BetweenTest.php
+++ b/tests/Rule/BetweenTest.php
@@ -62,7 +62,7 @@ class BetweenTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $result->getMessages());
     }
 
-    public function getMessage($reason)
+    private function getMessage($reason)
     {
         $messages = [
             Between::TOO_SMALL => 'number must be greater than or equal to 1',

--- a/tests/Rule/BooleanTest.php
+++ b/tests/Rule/BooleanTest.php
@@ -50,7 +50,7 @@ class BooleanTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
-    public function getMessage($reason)
+    private function getMessage($reason)
     {
         $messages = [
             Boolean::NOT_BOOL => 'active must be either true or false'

--- a/tests/Rule/CallbackTest.php
+++ b/tests/Rule/CallbackTest.php
@@ -79,7 +79,7 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($result->isValid());
     }
 
-    public function getMessage($reason)
+    private function getMessage($reason)
     {
         $messages = [
             Callback::INVALID_VALUE => 'first name is invalid'

--- a/tests/Rule/DatetimeTest.php
+++ b/tests/Rule/DatetimeTest.php
@@ -117,7 +117,7 @@ class DatetimeTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($result->isValid());
     }
 
-    public function getMessage($reason)
+    private function getMessage($reason)
     {
         $messages = [
         ];

--- a/tests/Rule/DigitsTest.php
+++ b/tests/Rule/DigitsTest.php
@@ -50,7 +50,7 @@ class DigitsTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
-    public function getMessage($reason)
+    private function getMessage($reason)
     {
         $messages = [
             Digits::NOT_DIGITS => 'digits may only consist out of digits'

--- a/tests/Rule/IntegerTest.php
+++ b/tests/Rule/IntegerTest.php
@@ -117,7 +117,7 @@ class IntegerTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
-    public function getMessage($reason)
+    private function getMessage($reason)
     {
         $messages = [
             Integer::NOT_AN_INTEGER => 'integer must be an integer'

--- a/tests/Rule/IsArrayTest.php
+++ b/tests/Rule/IsArrayTest.php
@@ -82,7 +82,7 @@ class IsArrayTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
-    public function getMessage($reason)
+    private function getMessage($reason)
     {
         $messages = [
             IsArray::NOT_AN_ARRAY => 'array must be an array'

--- a/tests/Rule/LengthBetweenTest.php
+++ b/tests/Rule/LengthBetweenTest.php
@@ -61,7 +61,7 @@ class LengthBetweenTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $result->getMessages());
     }
 
-    public function getMessage($reason)
+    private function getMessage($reason)
     {
         $messages = [
             LengthBetween::TOO_SHORT => 'first name must be 3 characters or longer',

--- a/tests/Rule/LengthTest.php
+++ b/tests/Rule/LengthTest.php
@@ -58,7 +58,7 @@ class LengthTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
-    public function getMessage($reason)
+    private function getMessage($reason)
     {
         $messages = [
             Length::TOO_SHORT => 'first name is too short and must be 5 characters long',

--- a/tests/Rule/NumericTest.php
+++ b/tests/Rule/NumericTest.php
@@ -70,7 +70,7 @@ class NumericTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
-    public function getMessage($reason)
+    private function getMessage($reason)
     {
         $messages = [
             Numeric::NOT_NUMERIC => 'number must be numeric'


### PR DESCRIPTION
This PR

* [x] reduces visibility of `getMessage()` from `public` to `private`

💁 There's no need for these methods to be publicly accessible. Besides, they are already `private` in

* [`GreaterThanTest`](https://github.com/particle-php/Validator/blob/a7d08c95831fd09b8907ff2ef7dd9715cb59af1d/tests/Rule/GreaterThanTest.php#L58)
* [`LessThanTest`](https://github.com/particle-php/Validator/blob/a7d08c95831fd09b8907ff2ef7dd9715cb59af1d/tests/Rule/LessThanTest.php#L58)