### PR TITLE
Enhancement: Implement IsString rule

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -105,6 +105,10 @@ Validates that the value is a valid phone number for `$countryCode`. Uses a libr
 
 Validates that the value matches the regular expression `$regex`.
 
+### string
+
+Validates that the value represents a `string`.
+
 ### url($schemes = [])
 
 Validates that the value is a valid URL. If the schemes array is passed, the URL must be in one of those schemes.

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -330,6 +330,16 @@ class Chain
     }
 
     /**
+     * Validates that the value represents a string.
+     *
+     * @return $this
+     */
+    public function string()
+    {
+        return $this->addRule(new Rule\IsString());
+    }
+
+    /**
      * Validates that the value is a valid URL. The schemes array is to selectively whitelist URL schemes.
      *
      * @param array $schemes

--- a/src/Rule/IsString.php
+++ b/src/Rule/IsString.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/validator/blob/master/LICENSE New BSD License
+ */
+namespace Particle\Validator\Rule;
+
+use Particle\Validator\Rule;
+
+/**
+ * This rule is for validating if a value represents a string.
+ *
+ * @package Particle\Validator\Rule
+ */
+class IsString extends Rule
+{
+    /**
+     * A constant that will be used when the value does not represent a string.
+     */
+    const NOT_A_STRING = 'IsString::NOT_A_STRING';
+
+    /**
+     * The message templates which can be returned by this validator.
+     *
+     * @var array
+     */
+    protected $messageTemplates = [
+        self::NOT_A_STRING => '{{ name }} must be a string',
+    ];
+
+    /**
+     * Validates if $value represents a string.
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function validate($value)
+    {
+        if (is_string($value)) {
+            return true;
+        }
+
+        return $this->error(self::NOT_A_STRING);
+    }
+}

--- a/tests/Rule/IsStringTest.php
+++ b/tests/Rule/IsStringTest.php
@@ -1,0 +1,74 @@
+<?php
+namespace Particle\Validator\Tests\Rule;
+
+use Particle\Validator\Rule\IsString;
+use Particle\Validator\Validator;
+
+class IsStringTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Validator
+     */
+    protected $validator;
+
+    protected function setUp()
+    {
+        $this->validator = new Validator();
+    }
+
+    public function testReturnsTrueOnValidString()
+    {
+        $value = 'foo';
+
+        $this->validator->required('value')->string();
+
+        $result = $this->validator->validate([
+            'value' => $value,
+        ]);
+
+        $this->assertTrue($result->isValid());
+    }
+
+    /**
+     * @dataProvider getInvalidStringValues
+     *
+     * @param mixed $value
+     */
+    public function testReturnsFalseOnInvalidString($value)
+    {
+        $this->validator->required('value')->string();
+
+        $result = $this->validator->validate([
+            'value' => $value,
+        ]);
+
+        $this->assertFalse($result->isValid());
+
+        $expected = [
+            'value' => [
+                IsString::NOT_A_STRING => $this->getMessage(IsString::NOT_A_STRING),
+            ],
+        ];
+
+        $this->assertEquals($expected, $result->getMessages());
+    }
+
+    public function getInvalidStringValues()
+    {
+        return [
+            [9000],
+            [3.14],
+            [true],
+            [new \stdClass()],
+        ];
+    }
+
+    private function getMessage($reason)
+    {
+        $messages = [
+            IsString::NOT_A_STRING => 'value must be a string',
+        ];
+
+        return $messages[$reason];
+    }
+}


### PR DESCRIPTION
### What?

Add an `IsString` rule, which validates whether a value represents a `string`.

### Checklist

- [x] Added unit test for added/fixed code
- [x] Updated the documentation
- [x] Scrutinizer code coverage is 100%
- [x] Scrutinizer code quality is as high as possible

### Linked issue

None.

💁 Not sure if this makes sense, but seems like a logical consequence, given that we have

* `Integer`
* `IsArray`
* `Numeric`

Question: Should we also have an `IsFloat` rule?
