### PR TITLE
Enhancement: Implement IsFloat rule

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -52,6 +52,10 @@ Validates that the value is a date. If format is passed, it *must* be in that fo
 
 Validates that all characters of the value are decimal digits.
 
+### float
+
+Validates that the value represents a `float`.
+
 ### integer($strict = false)
 
 Validates that the value represents a valid integer.

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -193,6 +193,16 @@ class Chain
     }
 
     /**
+     * Validates that the value represents a float.
+     *
+     * @return $this
+     */
+    public function float()
+    {
+        return $this->addRule(new Rule\IsFloat());
+    }
+
+    /**
      * Validates that the value is greater than $value.
      *
      * @param int $value

--- a/src/Rule/IsFloat.php
+++ b/src/Rule/IsFloat.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/validator/blob/master/LICENSE New BSD License
+ */
+namespace Particle\Validator\Rule;
+
+use Particle\Validator\Rule;
+
+/**
+ * This rule is for validating if a value represents a float.
+ *
+ * @package Particle\Validator\Rule
+ */
+class IsFloat extends Rule
+{
+    /**
+     * A constant that will be used when the value does not represent a float.
+     */
+    const NOT_A_FLOAT = 'IsFloat::NOT_A_FLOAT';
+
+    /**
+     * The message templates which can be returned by this validator.
+     *
+     * @var array
+     */
+    protected $messageTemplates = [
+        self::NOT_A_FLOAT => '{{ name }} must be a float',
+    ];
+
+    /**
+     * Validates if $value represents a float.
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function validate($value)
+    {
+        if (is_float($value)) {
+            return true;
+        }
+
+        return $this->error(self::NOT_A_FLOAT);
+    }
+}

--- a/tests/Rule/IsFloatTest.php
+++ b/tests/Rule/IsFloatTest.php
@@ -1,0 +1,74 @@
+<?php
+namespace Particle\Validator\Tests\Rule;
+
+use Particle\Validator\Rule\IsFloat;
+use Particle\Validator\Validator;
+
+class IsFloatTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Validator
+     */
+    protected $validator;
+
+    protected function setUp()
+    {
+        $this->validator = new Validator();
+    }
+
+    public function testReturnsTrueOnValidFloat()
+    {
+        $value = 3.14;
+
+        $this->validator->required('value')->float();
+
+        $result = $this->validator->validate([
+            'value' => $value,
+        ]);
+
+        $this->assertTrue($result->isValid());
+    }
+
+    /**
+     * @dataProvider getInvalidFloatValues
+     *
+     * @param mixed $value
+     */
+    public function testReturnsFalseOnInvalidFloat($value)
+    {
+        $this->validator->required('value')->float();
+
+        $result = $this->validator->validate([
+            'value' => $value,
+        ]);
+
+        $this->assertFalse($result->isValid());
+
+        $expected = [
+            'value' => [
+                IsFloat::NOT_A_FLOAT => $this->getMessage(IsFloat::NOT_A_FLOAT),
+            ],
+        ];
+
+        $this->assertEquals($expected, $result->getMessages());
+    }
+
+    public function getInvalidFloatValues()
+    {
+        return [
+            ['foo'],
+            [9000],
+            [true],
+            [new \stdClass()],
+        ];
+    }
+
+    private function getMessage($reason)
+    {
+        $messages = [
+            IsFloat::NOT_A_FLOAT => 'value must be a float',
+        ];
+
+        return $messages[$reason];
+    }
+}


### PR DESCRIPTION
### What?

Add an `IsFloat` rule, which validates whether a value represents a `float`.

### Checklist

- [x] Added unit test for added/fixed code
- [x] Updated the documentation
- [x] Scrutinizer code coverage is 100%
- [x] Scrutinizer code quality is as high as possible

### Linked issue

* #138

💁 Not sure if this is too simple, for example, when comparing this with [`Zend\I18n\Validator\IsFloat`](https://github.com/zendframework/zend-i18n/blob/master/src/Validator/IsFloat.php). On the other hand, the existing validators don't take i18n issues into account either.