### PR TITLE
Feature/optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $result->getMessages();
 * Ability to separate controller and view logic
 * Fully documented: [validator.particle-php.com](http://validator.particle-php.com)
 * Fully tested: [Scrutinizer](https://scrutinizer-ci.com/g/particle-php/Validator/)
-* Very few dependencies
+* Zero dependencies
 
 ===
 

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,17 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
-        "byrokrat/checkdigit": "^1.0",
-        "giggsey/libphonenumber-for-php": "^7.2"
+        "php": ">=5.4"
+    },
+    "suggest": {
+        "byrokrat/checkdigit": "If you want to use CreditCard validation rule, this library must be installed.",
+        "giggsey/libphonenumber-for-php": "If you want to use Phone validation rule, this library must be installed."
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",
-        "squizlabs/php_codesniffer": "2.*"
+        "squizlabs/php_codesniffer": "2.*",
+        "byrokrat/checkdigit": "^1.0",
+        "giggsey/libphonenumber-for-php": "^7.2"
     },
     "autoload": {
         "psr-4": {

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ design goals:
  - **Well-documented**, so that if you *do* go to the documentation, you don't have to search for long.
  - **Extensible**, so you can simply add your own rules, and error messages.
  - **Well-tested**, so that you're absolutely sure that you can rely on the validation rules.
- - **Very few** dependencies, so that you can use it in *any* PHP project.
+ - **Zero** dependencies, so that you can use it in *any* PHP project.
  
 Although there are many validation libraries out there, they seem to lack in one or more of the
 above design goals.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -44,6 +44,9 @@ $v->required('userId')->callback(function ($value) {
 
 Validates that the value is a valid credit card number checking for popular brand formats and using Luhn algorithm for validating the checksum.
 
+**Note:** If you want to use this rule, you must install the `byrokrat/checkdigit` package.
+Run `composer require byrokrat/checkdigit`.
+
 ### datetime($format = null)
 
 Validates that the value is a date. If format is passed, it *must* be in that format.
@@ -100,6 +103,9 @@ Validates that the value is numeric (so either a `float`, or an `integer`).
 ### phone($countryCode)
 
 Validates that the value is a valid phone number for `$countryCode`. Uses a library based on Google's `libphonenumber`.
+
+**Note:** If you want to use this rule, you must install the `giggsey/libphonenumber-for-php` package.
+Run `composer require giggsey/libphonenumber-for-php`.
 
 ### regex($regex)
 


### PR DESCRIPTION
### What?

This PR makes the dependencies optional, and suggests them instead if you want to use the `Phone` or `CreditCard` rule. Also the documentation of the rules now states explicitly that you need to require the packages if you want to use them.

Note that I moved the packages to `require-dev` to make sure that the tests are running.

### Checklist

- [x] Added unit test for added/fixed code
- [x] Updated the documentation
- [x] Scrutinizer code coverage is 100%
- [x] Scrutinizer code quality is as high as possible

### Linked issue

https://github.com/particle-php/Validator/issues/140
