### PR TITLE
Add `Inner` rule (WIP)

### DIFF
--- a/src/Chain.php
+++ b/src/Chain.php
@@ -176,7 +176,7 @@ class Chain
     }
 
     /**
-     * Validates a value to be a nested repeating arrays, which can then be validated using a new Validator instance.
+     * Validates a value to be nested repeating arrays, which can then be validated using a new Validator instance.
      *
      * @param callable $callback
      * @return $this

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -176,7 +176,7 @@ class Chain
     }
 
     /**
-     * Validates a value to be a nested array, which can then be validated using a new Validator instance.
+     * Validates a value to be a nested repiting arrays, which can then be validated using a new Validator instance.
      *
      * @param callable $callback
      * @return $this
@@ -250,6 +250,17 @@ class Chain
     public function inArray(array $array, $strict = Rule\InArray::STRICT)
     {
         return $this->addRule(new Rule\InArray($array, $strict));
+    }
+
+    /**
+     * Validates a value to be a nested array, which can then be validated using a new Validator instance.
+     *
+     * @param callable $callback
+     * @return Chain
+     */
+    public function inner(callable $callback)
+    {
+        return $this->addRule(new Rule\Inner($callback));
     }
 
     /**

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -176,7 +176,7 @@ class Chain
     }
 
     /**
-     * Validates a value to be a nested repiting arrays, which can then be validated using a new Validator instance.
+     * Validates a value to be a nested repeating arrays, which can then be validated using a new Validator instance.
      *
      * @param callable $callback
      * @return $this

--- a/src/Rule/Inner.php
+++ b/src/Rule/Inner.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Particle.
+ *
+ * @link      http://github.com/particle-php for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Particle (http://particle-php.com)
+ * @license   https://github.com/particle-php/validator/blob/master/LICENSE New BSD License
+ */
+namespace Particle\Validator\Rule;
+
+use Particle\Validator\Rule;
+use Particle\Validator\ValidationResult;
+use Particle\Validator\Validator;
+
+/**
+ * This rule is for validating nested arrays.
+ *
+ * @package Particle\Validator\Rule
+ */
+class Inner extends Rule
+{
+    const NOT_AN_ARRAY = 'Inner::NOT_AN_ARRAY';
+
+    /**
+     * The message templates which can be returned by this validator.
+     *
+     * @var array
+     */
+    protected $messageTemplates = [
+        self::NOT_AN_ARRAY => '{{ name }} must be an array',
+    ];
+
+    /**
+     * @var callable
+     */
+    protected $callback;
+
+    /**
+     * @param callable $callback
+     */
+    public function __construct(callable $callback)
+    {
+        $this->callback = $callback;
+    }
+
+    /**
+     * Validates if $value is array, validate inner array of $value, and return result.
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function validate($value)
+    {
+        if (!is_array($value)) {
+            return $this->error(self::NOT_AN_ARRAY);
+        }
+
+        $validator = new Validator();
+
+        call_user_func($this->callback, $validator, $value);
+
+        $result = $validator->validate($value);
+
+        if (!$result->isValid()) {
+            $this->handleError($result);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param ValidationResult $result
+     */
+    protected function handleError($result)
+    {
+        foreach ($result->getFailures() as $failure) {
+            $failure->overwriteKey(
+                sprintf('%s.%s', $this->key, $failure->getKey())
+            );
+
+            $this->messageStack->append($failure);
+        }
+    }
+}

--- a/tests/Rule/InnerTest.php
+++ b/tests/Rule/InnerTest.php
@@ -1,0 +1,47 @@
+<?php
+namespace Particle\Validator\Tests\Rule;
+
+use Particle\Validator\Validator;
+
+class InnerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Validator
+     */
+    protected $validator;
+
+    protected function setUp()
+    {
+        $this->validator = new Validator();
+    }
+
+    public function testCanValidateNestedArrays()
+    {
+        $data = [
+            'user' => [
+                'id' => 1,
+                'first_name' => 'Alexander',
+                'last_name' => 'Kochetov',
+                'profile' => [
+                    'email' => 'creocoder@gmail.com',
+                    'registered_at' => '2016-09-24',
+                ],
+            ],
+        ];
+
+        $this->validator->required('user')->inner(function (Validator $userValidator) {
+            $userValidator->required('id')->integer();
+            $userValidator->required('first_name')->string();
+            $userValidator->required('last_name')->string();
+            $userValidator->required('profile')->inner(function (Validator $profileValidator) {
+                $profileValidator->required('email')->email();
+                $profileValidator->required('registered_at')->datetime('Y-m-d');
+            });
+        });
+
+        $result = $this->validator->validate($data);
+
+        $this->assertTrue($result->isValid());
+        $this->assertEquals([], $result->getMessages());
+    }
+}

--- a/tests/Rule/InnerTest.php
+++ b/tests/Rule/InnerTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Particle\Validator\Tests\Rule;
 
+use Particle\Validator\Rule\Inner;
 use Particle\Validator\Validator;
 
 class InnerTest extends \PHPUnit_Framework_TestCase
@@ -43,5 +44,26 @@ class InnerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($result->isValid());
         $this->assertEquals([], $result->getMessages());
+    }
+
+    public function testReturnsErrorOnNonArray()
+    {
+        $this->validator->required('foo')->inner(function (Validator $validator) {
+            $validator->required('bar')->bool();
+        });
+
+        $result = $this->validator->validate([
+            'foo' => 1
+        ]);
+
+        $this->assertFalse($result->isValid());
+
+        $expected = [
+            'foo' => [
+                Inner::NOT_AN_ARRAY => 'foo must be an array',
+            ]
+        ];
+
+        $this->assertEquals($expected, $result->getMessages());
     }
 }


### PR DESCRIPTION
### What?

**Simple example:**

``` php
use Particle\Validator\Validator;

$validator = new Validator();

$validator->required('user')->inner(function (Validator $userValidator) {
    $userValidator->required('id')->integer();
    $userValidator->required('first_name')->string();
    $userValidator->required('last_name')->string();
    $userValidator->required('profile')->inner(function (Validator $profileValidator) {
        $profileValidator->required('email')->email();
        $profileValidator->required('registered_at')->datetime('Y-m-d');
    });
});

$validator->validate([
    'user' => [
        'id' => 1,
        'first_name' => 'Alexander',
        'last_name' => 'Kochetov',
        'profile' => [
            'email' => 'creocoder@gmail.com',
            'registered_at' => '2016-09-24',
        ],
    ],
]);
```

**Advanced features (adding rules by condition):**

``` php
use Particle\Validator\Validator;

$validator = new Validator();

$validator->required('scheduling')->inner(function (Validator $schedulingValidator, $value) {
    // ...
}
```

To be detailed...
### Checklist
- [x] Added unit test for added/fixed code
- [ ] Updated the documentation
- [ ] Scrutinizer code coverage is 100%
- [ ] Scrutinizer code quality is as high as possible

Work in progress...

P.S. `Each` rule may be refactored after merging this, `Each` rule callback signature should be also enhanced to support same features.
