### PR TITLE
Added multibyte string functions

### DIFF
--- a/src/Chain.php
+++ b/src/Chain.php
@@ -290,11 +290,12 @@ class Chain
      * Validate the value to be of precisely length $length.
      *
      * @param int $length
+     * @param string|null $encoding
      * @return $this
      */
-    public function length($length)
+    public function length($length, $encoding = null)
     {
-        return $this->addRule(new Rule\Length($length));
+        return $this->addRule(new Rule\Length($length, $encoding));
     }
 
     /**
@@ -304,11 +305,12 @@ class Chain
      *
      * @param int $min
      * @param int|null $max
+     * @param string|null $encoding
      * @return $this
      */
-    public function lengthBetween($min, $max)
+    public function lengthBetween($min, $max, $encoding = null)
     {
-        return $this->addRule(new Rule\LengthBetween($min, $max));
+        return $this->addRule(new Rule\LengthBetween($min, $max, $encoding));
     }
 
     /**

--- a/src/Rule/Length.php
+++ b/src/Rule/Length.php
@@ -45,13 +45,22 @@ class Length extends Rule
     protected $length;
 
     /**
+     * The encoding to be used for multibyte string functions.
+     *
+     * @var null|string
+     */
+    protected $encoding;
+
+    /**
      * Construct the Length validator.
      *
      * @param int $length
+     * @param null|string $encoding
      */
-    public function __construct($length)
+    public function __construct($length, $encoding = null)
     {
         $this->length = $length;
+        $this->encoding = $encoding;
     }
 
     /**
@@ -62,8 +71,12 @@ class Length extends Rule
      */
     public function validate($value)
     {
-        $actualLength = strlen($value);
-
+        if (is_null($this->encoding) || !function_exists('mb_strlen')) {
+            $actualLength = strlen($value);
+        } else {
+            $actualLength = mb_strlen($value, $this->encoding);
+        }
+        
         if ($actualLength > $this->length) {
             return $this->error(self::TOO_LONG);
         }

--- a/src/Rule/LengthBetween.php
+++ b/src/Rule/LengthBetween.php
@@ -52,13 +52,22 @@ class LengthBetween extends Between
     protected $min;
 
     /**
+     * The encoding to be used for multibyte string functions.
+     *
+     * @var string|null
+     */
+    protected $encoding;
+
+    /**
      * @param int $min
      * @param int|null $max
+     * @param string|null $encoding
      */
-    public function __construct($min, $max)
+    public function __construct($min, $max, $encoding = null)
     {
         $this->min = $min;
         $this->max = $max;
+        $this->encoding = $encoding;
     }
 
     /**
@@ -69,7 +78,11 @@ class LengthBetween extends Between
      */
     public function validate($value)
     {
-        $length = strlen($value);
+        if (is_null($this->encoding) || !function_exists('mb_strlen')) {
+            $length = strlen($value);
+        } else {
+            $length = mb_strlen($value, $this->encoding);
+        }
 
         return !$this->tooSmall($length, self::TOO_SHORT) && !$this->tooLarge($length, self::TOO_LONG);
     }

--- a/tests/Rule/LengthTest.php
+++ b/tests/Rule/LengthTest.php
@@ -23,7 +23,7 @@ class LengthTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidValuesWillReturnFalseAndLogError($value, $error)
     {
-        $this->validator->required('first_name')->length(5);
+        $this->validator->required('first_name')->length(5, 'UTF-8');
         $result = $this->validator->validate(['first_name' => $value]);
 
         $expected = ['first_name' => [$error => $this->getMessage($error)]];
@@ -37,7 +37,7 @@ class LengthTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidValuesWillReturnTrue($value)
     {
-        $this->validator->required('first_name')->length(5);
+        $this->validator->required('first_name')->length(5, 'UTF-8');
         $result = $this->validator->validate(['first_name' => $value]);
         $this->assertTrue($result->isValid());
     }
@@ -46,7 +46,8 @@ class LengthTest extends \PHPUnit_Framework_TestCase
     {
         return [
             ['rick', Length::TOO_SHORT],
-            ['hendrik', Length::TOO_LONG]
+            ['hendrik', Length::TOO_LONG],
+            ['loïc', Length::TOO_SHORT], // UTF-8 multibyte test
         ];
     }
 
@@ -54,7 +55,8 @@ class LengthTest extends \PHPUnit_Framework_TestCase
     {
         return [
             ['berry'],
-            [12345] // integers are cast to strings
+            [12345], // integers are cast to strings
+            ['björk'], // UTF-8 multibyte test
         ];
     }
 


### PR DESCRIPTION
### What?

Adds the possibilty to use multibyte string functions in the rules "length" and "lengthBetween".

### Checklist

- [x] Added unit test for added/fixed code
- [ ] Updated the documentation
- [x] Scrutinizer code coverage is 100%
- [x] Scrutinizer code quality is as high as possible

### Linked issue

#160 

### Notes

- I have not yet updated the documentation.
- I modified the current unit tests for `LengthTest` only. Probably it would be better to make a new class `LengthTestMultibyte` which actually tests the multibyte cases. Because right now, I have change the `LengthTest` such that it always uses the multibyte functions. But in my opinion this unit test should only contain the original rule without encoding.