### PR TITLE
fix typo in example usage of getMessageParameters()

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -80,7 +80,7 @@ class GrumpyRule extends Rule
     // these variables can be used in error messages.
     protected function getMessageParameters()
     {
-        return array_merge(parent::getMessageParameters, [
+        return array_merge(parent::getMessageParameters(), [
             'who' => $this->who,
         ]);
     }


### PR DESCRIPTION
### What?

documentation example on "Extending Validator" mistakenly uses `parent::getMessageParameters` instead of `parent::getMessageParameters()`

### Checklist

- [x] Updated the documentation
