### PR TITLE
Enhance `Required` rule

### DIFF
--- a/src/Rule/Required.php
+++ b/src/Rule/Required.php
@@ -124,7 +124,7 @@ class Required extends Rule
      */
     public function setRequired($required)
     {
-        if (is_callable($required)) {
+        if (is_callable($required) || is_array($required)) {
             return $this->setRequiredCallback($required);
         }
 


### PR DESCRIPTION
### What?

Allow to use `required` rule with syntax like:

```
$validator->optional('key')->required([$this, 'checkMethod']); // will work after merge
```

Note that `callback` validator is already support such type of syntax:

```
$validator->optional('key')->callback([$this, 'checkMethod']); // already work
```