### PR TITLE
Enhance `NotEmpty` rule

### DIFF
--- a/src/Rule/NotEmpty.php
+++ b/src/Rule/NotEmpty.php
@@ -140,7 +140,7 @@ class NotEmpty extends Rule
      */
     public function setAllowEmpty($allowEmpty)
     {
-        if (is_callable($allowEmpty)) {
+        if (is_callable($allowEmpty) || is_array($allowEmpty)) {
             return $this->setAllowEmptyCallback($allowEmpty);
         }
         return $this->overwriteAllowEmpty($allowEmpty);


### PR DESCRIPTION
### What?

Allow to use `allowEmpty` rule with syntax like:

```
$validator->optional('key')->allowEmpty([$this, 'checkMethod']); // will work after merge
```

Note that `callback` validator is already support such type of syntax:

```
$validator->optional('key')->callback([$this, 'checkMethod']); // already work
```