### PR TITLE
Fix break chain for type checking rules

### DIFF
--- a/src/Rule/Boolean.php
+++ b/src/Rule/Boolean.php
@@ -41,4 +41,12 @@ class Boolean extends Rule
     {
         return is_bool($value) ?: $this->error(self::NOT_BOOL);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function shouldBreakChain()
+    {
+        return true;
+    }
 }

--- a/src/Rule/Integer.php
+++ b/src/Rule/Integer.php
@@ -74,4 +74,12 @@ class Integer extends Rule
 
         return $this->error(self::NOT_AN_INTEGER);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function shouldBreakChain()
+    {
+        return true;
+    }
 }

--- a/src/Rule/IsArray.php
+++ b/src/Rule/IsArray.php
@@ -45,4 +45,12 @@ class IsArray extends Rule
 
         return $this->error(self::NOT_AN_ARRAY);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function shouldBreakChain()
+    {
+        return true;
+    }
 }

--- a/src/Rule/IsFloat.php
+++ b/src/Rule/IsFloat.php
@@ -45,4 +45,12 @@ class IsFloat extends Rule
 
         return $this->error(self::NOT_A_FLOAT);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function shouldBreakChain()
+    {
+        return true;
+    }
 }

--- a/src/Rule/IsString.php
+++ b/src/Rule/IsString.php
@@ -45,4 +45,12 @@ class IsString extends Rule
 
         return $this->error(self::NOT_A_STRING);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function shouldBreakChain()
+    {
+        return true;
+    }
 }

--- a/tests/ChainTest.php
+++ b/tests/ChainTest.php
@@ -1,6 +1,12 @@
 <?php
 namespace Particle\Validator\Tests;
 
+use Particle\Validator\Rule;
+use Particle\Validator\Rule\Boolean;
+use Particle\Validator\Rule\Integer;
+use Particle\Validator\Rule\IsArray;
+use Particle\Validator\Rule\IsFloat;
+use Particle\Validator\Rule\IsString;
 use Particle\Validator\Tests\Support\CustomRule;
 use Particle\Validator\Validator;
 
@@ -32,5 +38,90 @@ class ChainTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($result->isValid());
         $this->assertEquals($expected, $result->getMessages());
+    }
+
+    /**
+     * @dataProvider providePrimitiveRulesData
+     *
+     * @param Rule $rule
+     * @param array $data
+     * @param array $expected
+     */
+    public function testBreakChain($rule, $data, $expected)
+    {
+        $this
+            ->validator
+            ->required('foo')
+            ->mount($rule)
+            ->lengthBetween(1, 50);
+
+        $result = $this->validator->validate($data);
+
+        $this->assertFalse($result->isValid());
+        $this->assertEquals($expected, $result->getMessages());
+    }
+
+    /**
+     * @return array
+     */
+    public function providePrimitiveRulesData()
+    {
+        return [
+            [
+                new Boolean(),
+                [
+                    'foo' => 'string',
+                ],
+                [
+                    'foo' => [
+                        Boolean::NOT_BOOL => 'foo must be either true or false',
+                    ],
+                ],
+            ],
+            [
+                new Integer(),
+                [
+                    'foo' => 'string',
+                ],
+                [
+                    'foo' => [
+                        Integer::NOT_AN_INTEGER => 'foo must be an integer',
+                    ],
+                ],
+            ],
+            [
+                new IsArray(),
+                [
+                    'foo' => 'string',
+                ],
+                [
+                    'foo' => [
+                        IsArray::NOT_AN_ARRAY => 'foo must be an array',
+                    ],
+                ],
+            ],
+            [
+                new IsFloat(),
+                [
+                    'foo' => 'string',
+                ],
+                [
+                    'foo' => [
+                        IsFloat::NOT_A_FLOAT => 'foo must be a float',
+                    ],
+                ],
+            ],
+            [
+                new IsString(),
+                [
+                    'foo' => ['array-value'],
+                ],
+                [
+                    'foo' => [
+                        IsString::NOT_A_STRING => 'foo must be a string',
+                    ],
+                ],
+            ],
+        ];
     }
 }


### PR DESCRIPTION
### What?

```php
$validator
            ->required('key')
            ->string()
            ->lengthBetween(1, 255);

$result = $validator->validate(
    [
        'key' => ['string'],
    ]
);
```
### What is the result?
```php
PHP: Exception
strlen() expects parameter 1 to be string, array given
```
### What the result should be?
```php
[
    'key' => [
        IsString::NOT_A_STRING => 'key must be a string,
    ],
],
```

### Checklist

- [x] Added unit test for added/fixed code

### Linked issue

https://github.com/particle-php/Validator/issues/174

### Proposal
This PR is a fast fix for trivial bug.
However I think this case should be treated more serious, and the code should be refactored to be more user friendly.

For example the worse thing is that the `shouldBreakChain()` method return a hardcoded value which is impossible to be changed without nesting the rule.

I think will be much better to have something like this: 
`$validator->required('key')->string(['breakChain' => true/false])`
or something else that will give a possibility to change this property dynamically.