### PR TITLE
[CRITICAL] Consider the break chain only in case the validation fail

### DIFF
--- a/src/Chain.php
+++ b/src/Chain.php
@@ -450,7 +450,7 @@ class Chain
 
             $valid = $rule->isValid($this->key, $input) && $valid;
 
-            if ($rule->shouldBreakChain() && !$valid) {
+            if (!$valid && $rule->shouldBreakChainOnError() || $rule->shouldBreakChain()) {
                 break;
             }
         }

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -450,7 +450,7 @@ class Chain
 
             $valid = $rule->isValid($this->key, $input) && $valid;
 
-            if ($rule->shouldBreakChain()) {
+            if ($rule->shouldBreakChain() && !$valid) {
                 break;
             }
         }

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -72,6 +72,16 @@ abstract class Rule
     }
 
     /**
+     * This indicates whether or not the rule should break the chain it's in on validation failure.
+     *
+     * @return bool
+     */
+    public function shouldBreakChainOnError()
+    {
+        return false;
+    }
+
+    /**
      * Registers the message stack to append errors to.
      *
      * @param MessageStack $messageStack

--- a/src/Rule/Boolean.php
+++ b/src/Rule/Boolean.php
@@ -45,7 +45,7 @@ class Boolean extends Rule
     /**
      * {@inheritdoc}
      */
-    public function shouldBreakChain()
+    public function shouldBreakChainOnError()
     {
         return true;
     }

--- a/src/Rule/Integer.php
+++ b/src/Rule/Integer.php
@@ -78,7 +78,7 @@ class Integer extends Rule
     /**
      * {@inheritdoc}
      */
-    public function shouldBreakChain()
+    public function shouldBreakChainOnError()
     {
         return true;
     }

--- a/src/Rule/IsArray.php
+++ b/src/Rule/IsArray.php
@@ -49,7 +49,7 @@ class IsArray extends Rule
     /**
      * {@inheritdoc}
      */
-    public function shouldBreakChain()
+    public function shouldBreakChainOnError()
     {
         return true;
     }

--- a/src/Rule/IsFloat.php
+++ b/src/Rule/IsFloat.php
@@ -49,7 +49,7 @@ class IsFloat extends Rule
     /**
      * {@inheritdoc}
      */
-    public function shouldBreakChain()
+    public function shouldBreakChainOnError()
     {
         return true;
     }

--- a/src/Rule/IsString.php
+++ b/src/Rule/IsString.php
@@ -49,7 +49,7 @@ class IsString extends Rule
     /**
      * {@inheritdoc}
      */
-    public function shouldBreakChain()
+    public function shouldBreakChainOnError()
     {
         return true;
     }

--- a/tests/ChainTest.php
+++ b/tests/ChainTest.php
@@ -42,7 +42,28 @@ class ChainTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $result->getMessages());
     }
 
-    public function testChain()
+    /**
+     * @dataProvider providePrimitiveRulesData
+     *
+     * @param Rule $rule
+     * @param array $data
+     * @param array $expected
+     */
+    public function testBreakChain($rule, $data, $expected)
+    {
+        $this
+            ->validator
+            ->required('foo')
+            ->mount($rule)
+            ->lengthBetween(1, 50);
+
+        $result = $this->validator->validate($data);
+
+        $this->assertFalse($result->isValid());
+        $this->assertEquals($expected, $result->getMessages());
+    }
+
+    public function testBreakChainOnFailure()
     {
         $this
             ->validator
@@ -63,25 +84,17 @@ class ChainTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @dataProvider providePrimitiveRulesData
-     *
-     * @param Rule $rule
-     * @param array $data
-     * @param array $expected
-     */
-    public function testBreakChain($rule, $data, $expected)
+    public function testBreakChainOnSuccess()
     {
         $this
             ->validator
             ->required('foo')
-            ->mount($rule)
-            ->lengthBetween(1, 50);
+            ->string()
+            ->lengthBetween(2, 5);
 
-        $result = $this->validator->validate($data);
+        $result = $this->validator->validate(['foo' => 'abc']);
 
-        $this->assertFalse($result->isValid());
-        $this->assertEquals($expected, $result->getMessages());
+        $this->assertTrue($result->isValid());
     }
 
     /**

--- a/tests/ChainTest.php
+++ b/tests/ChainTest.php
@@ -173,8 +173,7 @@ class ChainTest extends \PHPUnit_Framework_TestCase
             ],
             'do not break isArray rule' => [
                 new IsArray(),
-                new Each(function ($v) {
-                    /** @var Validator $v */
+                new Each(function (Validator $v) {
                     $v->required('bar')->email();
                 }),
                 [

--- a/tests/ChainTest.php
+++ b/tests/ChainTest.php
@@ -3,11 +3,16 @@ namespace Particle\Validator\Tests;
 
 use Particle\Validator\Rule;
 use Particle\Validator\Rule\Boolean;
+use Particle\Validator\Rule\Each;
+use Particle\Validator\Rule\Email;
+use Particle\Validator\Rule\GreaterThan;
+use Particle\Validator\Rule\InArray;
 use Particle\Validator\Rule\Integer;
 use Particle\Validator\Rule\IsArray;
 use Particle\Validator\Rule\IsFloat;
 use Particle\Validator\Rule\IsString;
 use Particle\Validator\Rule\LengthBetween;
+use Particle\Validator\Rule\Required;
 use Particle\Validator\Tests\Support\CustomRule;
 use Particle\Validator\Validator;
 
@@ -42,19 +47,20 @@ class ChainTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider providePrimitiveRulesData
+     * @dataProvider provideBreakChainData
      *
-     * @param Rule $rule
+     * @param Rule $firstRule
+     * @param Rule $secondRule
      * @param array $data
      * @param array $expected
      */
-    public function testBreakChain($rule, $data, $expected)
+    public function testBreakChain($firstRule, $secondRule, $data, $expected)
     {
         $this
             ->validator
             ->required('foo')
-            ->mount($rule)
-            ->lengthBetween(1, 50);
+            ->mount($firstRule)
+            ->mount($secondRule);
 
         $result = $this->validator->validate($data);
 
@@ -62,48 +68,15 @@ class ChainTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $result->getMessages());
     }
 
-    public function testBreakChainOnFailure()
-    {
-        $this
-            ->validator
-            ->required('foo')
-            ->string()
-            ->lengthBetween(2, 5);
-
-        $result = $this->validator->validate(['foo' => 'abcdefg']);
-
-        $this->assertFalse($result->isValid());
-        $this->assertEquals(
-            [
-                'foo' => [
-                    LengthBetween::TOO_LONG => 'foo must be 5 characters or shorter',
-                ],
-            ],
-            $result->getMessages()
-        );
-    }
-
-    public function testBreakChainOnSuccess()
-    {
-        $this
-            ->validator
-            ->required('foo')
-            ->string()
-            ->lengthBetween(2, 5);
-
-        $result = $this->validator->validate(['foo' => 'abc']);
-
-        $this->assertTrue($result->isValid());
-    }
-
     /**
      * @return array
      */
-    public function providePrimitiveRulesData()
+    public function provideBreakChainData()
     {
         return [
-            [
+            'break boolean rule on error' => [
                 new Boolean(),
+                new InArray([true, false]),
                 [
                     'foo' => 'string',
                 ],
@@ -113,8 +86,9 @@ class ChainTest extends \PHPUnit_Framework_TestCase
                     ],
                 ],
             ],
-            [
+            'break integer rule on error' => [
                 new Integer(),
+                new GreaterThan(10),
                 [
                     'foo' => 'string',
                 ],
@@ -124,8 +98,12 @@ class ChainTest extends \PHPUnit_Framework_TestCase
                     ],
                 ],
             ],
-            [
+            'break isArray rule on error' => [
                 new IsArray(),
+                new Each(function ($v) {
+                    /** @var Validator $v */
+                    $v->required('bar')->email();
+                }),
                 [
                     'foo' => 'string',
                 ],
@@ -135,8 +113,9 @@ class ChainTest extends \PHPUnit_Framework_TestCase
                     ],
                 ],
             ],
-            [
+            'break isFloat rule on error' => [
                 new IsFloat(),
+                new GreaterThan(20),
                 [
                     'foo' => 'string',
                 ],
@@ -146,14 +125,90 @@ class ChainTest extends \PHPUnit_Framework_TestCase
                     ],
                 ],
             ],
-            [
+            'break isString rule on error' => [
                 new IsString(),
+                new LengthBetween(1, 3),
                 [
                     'foo' => ['array-value'],
                 ],
                 [
                     'foo' => [
                         IsString::NOT_A_STRING => 'foo must be a string',
+                    ],
+                ],
+            ],
+            'break required rule' => [
+                new Boolean(),
+                new InArray([true, false]),
+                [],
+                [
+                    'foo' => [
+                        Required::NON_EXISTENT_KEY => 'foo must be provided, but does not exist',
+                    ],
+                ],
+            ],
+            'don not break boolean rule' => [
+                new Boolean(),
+                new InArray([false]),
+                [
+                    'foo' => true,
+                ],
+                [
+                    'foo' => [
+                        InArray::NOT_IN_ARRAY => 'foo must be in the defined set of values',
+                    ],
+                ],
+            ],
+            'don not break integer rule' => [
+                new Integer(),
+                new GreaterThan(10),
+                [
+                    'foo' => 5,
+                ],
+                [
+                    'foo' => [
+                        GreaterThan::NOT_GREATER_THAN => 'foo must be greater than 10',
+                    ],
+                ],
+            ],
+            'don not break isArray rule' => [
+                new IsArray(),
+                new Each(function ($v) {
+                    /** @var Validator $v */
+                    $v->required('bar')->email();
+                }),
+                [
+                    'foo' => [
+                        ['bar' => 'invalid@email'],
+                    ],
+                ],
+                [
+                    'foo.0.bar' => [
+                        Email::INVALID_FORMAT => 'bar must be a valid email address',
+                    ],
+                ],
+            ],
+            'don not break isFloat rule' => [
+                new IsFloat(),
+                new GreaterThan(20),
+                [
+                    'foo' => 5.00,
+                ],
+                [
+                    'foo' => [
+                        GreaterThan::NOT_GREATER_THAN => 'foo must be greater than 20',
+                    ],
+                ],
+            ],
+            'don not break isString rule' => [
+                new IsString(),
+                new LengthBetween(1, 3),
+                [
+                    'foo' => 'abcdefg',
+                ],
+                [
+                    'foo' => [
+                        LengthBetween::TOO_LONG => 'foo must be 3 characters or shorter',
                     ],
                 ],
             ],

--- a/tests/ChainTest.php
+++ b/tests/ChainTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Particle\Validator\Tests;
 
 use Particle\Validator\Rule;
@@ -34,8 +33,8 @@ class ChainTest extends \PHPUnit_Framework_TestCase
 
         $expected = [
             'foo' => [
-                CustomRule::NOT_BAR => 'foo must be equal to "bar"',
-            ],
+                CustomRule::NOT_BAR => 'foo must be equal to "bar"'
+            ]
         ];
 
         $this->assertFalse($result->isValid());

--- a/tests/ChainTest.php
+++ b/tests/ChainTest.php
@@ -147,7 +147,7 @@ class ChainTest extends \PHPUnit_Framework_TestCase
                     ],
                 ],
             ],
-            'don not break boolean rule' => [
+            'do not break boolean rule' => [
                 new Boolean(),
                 new InArray([false]),
                 [
@@ -159,7 +159,7 @@ class ChainTest extends \PHPUnit_Framework_TestCase
                     ],
                 ],
             ],
-            'don not break integer rule' => [
+            'do not break integer rule' => [
                 new Integer(),
                 new GreaterThan(10),
                 [
@@ -171,7 +171,7 @@ class ChainTest extends \PHPUnit_Framework_TestCase
                     ],
                 ],
             ],
-            'don not break isArray rule' => [
+            'do not break isArray rule' => [
                 new IsArray(),
                 new Each(function ($v) {
                     /** @var Validator $v */
@@ -188,7 +188,7 @@ class ChainTest extends \PHPUnit_Framework_TestCase
                     ],
                 ],
             ],
-            'don not break isFloat rule' => [
+            'do not break isFloat rule' => [
                 new IsFloat(),
                 new GreaterThan(20),
                 [
@@ -200,7 +200,7 @@ class ChainTest extends \PHPUnit_Framework_TestCase
                     ],
                 ],
             ],
-            'don not break isString rule' => [
+            'do not break isString rule' => [
                 new IsString(),
                 new LengthBetween(1, 3),
                 [

--- a/tests/ChainTest.php
+++ b/tests/ChainTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Particle\Validator\Tests;
 
 use Particle\Validator\Rule;
@@ -7,6 +8,7 @@ use Particle\Validator\Rule\Integer;
 use Particle\Validator\Rule\IsArray;
 use Particle\Validator\Rule\IsFloat;
 use Particle\Validator\Rule\IsString;
+use Particle\Validator\Rule\LengthBetween;
 use Particle\Validator\Tests\Support\CustomRule;
 use Particle\Validator\Validator;
 
@@ -32,12 +34,33 @@ class ChainTest extends \PHPUnit_Framework_TestCase
 
         $expected = [
             'foo' => [
-                CustomRule::NOT_BAR => 'foo must be equal to "bar"'
-            ]
+                CustomRule::NOT_BAR => 'foo must be equal to "bar"',
+            ],
         ];
 
         $this->assertFalse($result->isValid());
         $this->assertEquals($expected, $result->getMessages());
+    }
+
+    public function testChain()
+    {
+        $this
+            ->validator
+            ->required('foo')
+            ->string()
+            ->lengthBetween(2, 5);
+
+        $result = $this->validator->validate(['foo' => 'abcdefg']);
+
+        $this->assertFalse($result->isValid());
+        $this->assertEquals(
+            [
+                'foo' => [
+                    LengthBetween::TOO_LONG => 'foo must be 5 characters or shorter',
+                ],
+            ],
+            $result->getMessages()
+        );
     }
 
     /**


### PR DESCRIPTION
### What?
In case we have a chain of rules and one of the rule will have setup `break chain`, the validation will pass even with wrong data just because the next rules will be skipped by the chain.
The problem is that `break chain` should be considered only in case the specific rule fail but not always as it is right now. (Expecting `Required` rule.)

```php
$this
    ->validator
    ->required('foo')
    ->string()
    ->lengthBetween(2, 5);

$result = $this->validator->validate(['foo' => 'abcdefg']);

$isValid = $result->isValid(); // True instead of False.
```

### Checklist
- [x] Added unit test for added/fixed code

### Linked issue

https://github.com/particle-php/Validator/issues/179

### Note
Will be nice if you'll trigger the packages right after the fix will be merged, because the last time it took to much to be updated. 
It's a critical bug, which broke the all validation logic in existent projects.

### PR which confirm the bug
https://github.com/particle-php/Validator/pull/178