### PR TITLE
Reproduce the break chain bug

### DIFF
--- a/tests/ChainTest.php
+++ b/tests/ChainTest.php
@@ -7,6 +7,7 @@ use Particle\Validator\Rule\Integer;
 use Particle\Validator\Rule\IsArray;
 use Particle\Validator\Rule\IsFloat;
 use Particle\Validator\Rule\IsString;
+use Particle\Validator\Rule\LengthBetween;
 use Particle\Validator\Tests\Support\CustomRule;
 use Particle\Validator\Validator;
 
@@ -59,6 +60,40 @@ class ChainTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($result->isValid());
         $this->assertEquals($expected, $result->getMessages());
+    }
+
+    public function testBreakChainOnFailure()
+    {
+        $this
+            ->validator
+            ->required('foo')
+            ->string()
+            ->lengthBetween(2, 5);
+
+        $result = $this->validator->validate(['foo' => 'abcdefg']);
+
+        $this->assertFalse($result->isValid());
+        $this->assertEquals(
+            [
+                'foo' => [
+                    LengthBetween::TOO_LONG => 'foo must be 5 characters or shorter',
+                ],
+            ],
+            $result->getMessages()
+        );
+    }
+
+    public function testBreakChainOnSuccess()
+    {
+        $this
+            ->validator
+            ->required('foo')
+            ->string()
+            ->lengthBetween(2, 5);
+
+        $result = $this->validator->validate(['foo' => 'abc']);
+
+        $this->assertTrue($result->isValid());
     }
 
     /**

--- a/tests/ChainTest.php
+++ b/tests/ChainTest.php
@@ -3,11 +3,16 @@ namespace Particle\Validator\Tests;
 
 use Particle\Validator\Rule;
 use Particle\Validator\Rule\Boolean;
+use Particle\Validator\Rule\Each;
+use Particle\Validator\Rule\Email;
+use Particle\Validator\Rule\GreaterThan;
+use Particle\Validator\Rule\InArray;
 use Particle\Validator\Rule\Integer;
 use Particle\Validator\Rule\IsArray;
 use Particle\Validator\Rule\IsFloat;
 use Particle\Validator\Rule\IsString;
 use Particle\Validator\Rule\LengthBetween;
+use Particle\Validator\Rule\Required;
 use Particle\Validator\Tests\Support\CustomRule;
 use Particle\Validator\Validator;
 
@@ -42,19 +47,20 @@ class ChainTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider providePrimitiveRulesData
+     * @dataProvider provideBreakChainData
      *
-     * @param Rule $rule
+     * @param Rule $firstRule
+     * @param Rule $secondRule
      * @param array $data
      * @param array $expected
      */
-    public function testBreakChain($rule, $data, $expected)
+    public function testBreakChain($firstRule, $secondRule, $data, $expected)
     {
         $this
             ->validator
             ->required('foo')
-            ->mount($rule)
-            ->lengthBetween(1, 50);
+            ->mount($firstRule)
+            ->mount($secondRule);
 
         $result = $this->validator->validate($data);
 
@@ -62,48 +68,15 @@ class ChainTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $result->getMessages());
     }
 
-    public function testBreakChainOnFailure()
-    {
-        $this
-            ->validator
-            ->required('foo')
-            ->string()
-            ->lengthBetween(2, 5);
-
-        $result = $this->validator->validate(['foo' => 'abcdefg']);
-
-        $this->assertFalse($result->isValid());
-        $this->assertEquals(
-            [
-                'foo' => [
-                    LengthBetween::TOO_LONG => 'foo must be 5 characters or shorter',
-                ],
-            ],
-            $result->getMessages()
-        );
-    }
-
-    public function testBreakChainOnSuccess()
-    {
-        $this
-            ->validator
-            ->required('foo')
-            ->string()
-            ->lengthBetween(2, 5);
-
-        $result = $this->validator->validate(['foo' => 'abc']);
-
-        $this->assertTrue($result->isValid());
-    }
-
     /**
      * @return array
      */
-    public function providePrimitiveRulesData()
+    public function provideBreakChainData()
     {
         return [
-            [
+            'break boolean rule on error' => [
                 new Boolean(),
+                new InArray([true, false]),
                 [
                     'foo' => 'string',
                 ],
@@ -113,8 +86,9 @@ class ChainTest extends \PHPUnit_Framework_TestCase
                     ],
                 ],
             ],
-            [
+            'break integer rule on error' => [
                 new Integer(),
+                new GreaterThan(10),
                 [
                     'foo' => 'string',
                 ],
@@ -124,8 +98,12 @@ class ChainTest extends \PHPUnit_Framework_TestCase
                     ],
                 ],
             ],
-            [
+            'break isArray rule on error' => [
                 new IsArray(),
+                new Each(function ($v) {
+                    /** @var Validator $v */
+                    $v->required('bar')->email();
+                }),
                 [
                     'foo' => 'string',
                 ],
@@ -135,8 +113,9 @@ class ChainTest extends \PHPUnit_Framework_TestCase
                     ],
                 ],
             ],
-            [
+            'break isFloat rule on error' => [
                 new IsFloat(),
+                new GreaterThan(20),
                 [
                     'foo' => 'string',
                 ],
@@ -146,14 +125,90 @@ class ChainTest extends \PHPUnit_Framework_TestCase
                     ],
                 ],
             ],
-            [
+            'break isString rule on error' => [
                 new IsString(),
+                new LengthBetween(1, 3),
                 [
                     'foo' => ['array-value'],
                 ],
                 [
                     'foo' => [
                         IsString::NOT_A_STRING => 'foo must be a string',
+                    ],
+                ],
+            ],
+            'break required rule' => [
+                new Boolean(),
+                new InArray([true, false]),
+                [],
+                [
+                    'foo' => [
+                        Required::NON_EXISTENT_KEY => 'foo must be provided, but does not exist',
+                    ],
+                ],
+            ],
+            'don not break boolean rule' => [
+                new Boolean(),
+                new InArray([false]),
+                [
+                    'foo' => true,
+                ],
+                [
+                    'foo' => [
+                        InArray::NOT_IN_ARRAY => 'foo must be in the defined set of values',
+                    ],
+                ],
+            ],
+            'don not break integer rule' => [
+                new Integer(),
+                new GreaterThan(10),
+                [
+                    'foo' => 5,
+                ],
+                [
+                    'foo' => [
+                        GreaterThan::NOT_GREATER_THAN => 'foo must be greater than 10',
+                    ],
+                ],
+            ],
+            'don not break isArray rule' => [
+                new IsArray(),
+                new Each(function ($v) {
+                    /** @var Validator $v */
+                    $v->required('bar')->email();
+                }),
+                [
+                    'foo' => [
+                        ['bar' => 'invalid@email'],
+                    ],
+                ],
+                [
+                    'foo.0.bar' => [
+                        Email::INVALID_FORMAT => 'bar must be a valid email address',
+                    ],
+                ],
+            ],
+            'don not break isFloat rule' => [
+                new IsFloat(),
+                new GreaterThan(20),
+                [
+                    'foo' => 5.00,
+                ],
+                [
+                    'foo' => [
+                        GreaterThan::NOT_GREATER_THAN => 'foo must be greater than 20',
+                    ],
+                ],
+            ],
+            'don not break isString rule' => [
+                new IsString(),
+                new LengthBetween(1, 3),
+                [
+                    'foo' => 'abcdefg',
+                ],
+                [
+                    'foo' => [
+                        LengthBetween::TOO_LONG => 'foo must be 3 characters or shorter',
                     ],
                 ],
             ],


### PR DESCRIPTION
### What?
In case we have a chain of rules and one of rule will have sett up brick chain, the validation will pass even with wrong data juts because the next rules will be skipped by chain.
The problem is that break chain should be considered only in case the specific rule fail but not always as it is right now. (Expecting Required rule.)

```php
$this
    ->validator
    ->required('foo')
    ->string()
    ->lengthBetween(2, 5);

$result = $this->validator->validate(['foo' => 'abcdefg']);

$isValid = $result->isValid(); // True instead of False.
```

### Note
This PR is juts to reproduce the bug that persist in master branch.
**It should not be merged!**

### Related PR
https://github.com/particle-php/Validator/pull/177