### PR TITLE
Prove the bug with Container::traverse

### DIFF
--- a/tests/Value/ContainerTest.php
+++ b/tests/Value/ContainerTest.php
@@ -64,4 +64,13 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($expected, $this->container->getArrayCopy());
     }
+
+    public function testGet()
+    {
+        $container = new Container(['data' => '']);
+
+        $value = $container->has('data.unknown');
+
+        $this->assertFalse($value);
+    }
 }


### PR DESCRIPTION
### What?

There is a bug in `Container::traverse()` method.
The added `unit` tests will fail because of exception which is throw for non-array values.

## Expected
The added unit test should pass.