### PR TITLE
Fix Container::traverse() method

### DIFF
--- a/src/Value/Container.php
+++ b/src/Value/Container.php
@@ -91,7 +91,7 @@ class Container
     {
         $value = $this->values;
         foreach (explode('.', $key) as $part) {
-            if (!array_key_exists($part, $value)) {
+            if (!is_array($value) || !array_key_exists($part, $value)) {
                 return false;
             }
             $value = $value[$part];

--- a/tests/Value/ContainerTest.php
+++ b/tests/Value/ContainerTest.php
@@ -67,10 +67,9 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testGet()
     {
-        $container = new Container(['data' => '']);
+        $container = new Container(['data' => '', 'parent' => ['sub' => 8]]);
 
-        $value = $container->has('data.unknown');
-
-        $this->assertFalse($value);
+        $this->assertFalse($container->get('data.unknown'));
+        $this->assertSame(8, $container->get('parent.sub'));
     }
 }

--- a/tests/Value/ContainerTest.php
+++ b/tests/Value/ContainerTest.php
@@ -64,4 +64,13 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($expected, $this->container->getArrayCopy());
     }
+
+    public function testGet()
+    {
+        $container = new Container(['data' => '']);
+
+        $value = $container->has('data.unknown');
+
+        $this->assertFalse($value);
+    }
 }


### PR DESCRIPTION
### What?

This PR fix the bug in `Container::traverse()` method. We should ensure firstly that we are working with an array before checking for required key.

### When?
This is possible use case when we need a validator for nested array, but the input which should be validated contain a non-array value.

```php
// It will throw an exception if we'll provide such input: ['data' => 'someKey'];
// Instead it should fail the validation.
$validator->required('data.someKey')->string(); 
```

### Checklist

- [x] Added unit test for added/fixed code

### Related

The PR which prove the bug: https://github.com/particle-php/Validator/pull/184