### PR TITLE
Prove the bug in EachRule

### DIFF
--- a/tests/Rule/EachTest.php
+++ b/tests/Rule/EachTest.php
@@ -76,6 +76,21 @@ class EachTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $result->getMessages());
     }
 
+    public function testReturnsErrorOnNonArrayItem()
+    {
+        $this->validator->required('foo')->each(function (Validator $validator) {
+            $validator->required('bar')->bool();
+        });
+
+        $result = $this->validator->validate([
+            'foo' => [
+                'bar' => 1,
+            ],
+        ]);
+
+        $this->assertFalse($result->isValid());
+    }
+
     public function testCanValidateNestedArrays()
     {
         $this->validator->required('foo')->each(function (Validator $validator) {


### PR DESCRIPTION
### What?

`EachRule` didn't handle the case when elements are `non-array` values.
Because of that the `TypeError` is thrown instead of validation error.

### DO NOT MERGE IT!