### PR TITLE
Fix EachRule bug with non-array items

### DIFF
--- a/src/Rule/Each.php
+++ b/src/Rule/Each.php
@@ -21,6 +21,8 @@ class Each extends Rule
 {
     const NOT_AN_ARRAY = 'Each::NOT_AN_ARRAY';
 
+    const NOT_AN_ARRAY_ITEM = 'Each::NOT_AN_ARRAY_ITEM';
+
     /**
      * The message templates which can be returned by this validator.
      *
@@ -28,6 +30,7 @@ class Each extends Rule
      */
     protected $messageTemplates = [
         self::NOT_AN_ARRAY => '{{ name }} must be an array',
+        self::NOT_AN_ARRAY_ITEM => 'Each {{ name }} item must be an array',
     ];
 
     /**
@@ -57,6 +60,10 @@ class Each extends Rule
 
         $result = true;
         foreach ($value as $index => $innerValue) {
+            if (!is_array($innerValue)) {
+                return $this->error(self::NOT_AN_ARRAY_ITEM);
+            }
+
             $result = $this->validateValue($index, $innerValue) && $result;
         }
         return $result;

--- a/tests/Rule/EachTest.php
+++ b/tests/Rule/EachTest.php
@@ -76,6 +76,29 @@ class EachTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $result->getMessages());
     }
 
+    public function testReturnsErrorOnNonArrayItem()
+    {
+        $this->validator->required('foo')->each(function (Validator $validator) {
+            $validator->required('bar')->bool();
+        });
+
+        $result = $this->validator->validate([
+            'foo' => [
+                'bar' => 1,
+            ],
+        ]);
+
+        $this->assertFalse($result->isValid());
+
+        $expected = [
+            'foo' => [
+                Each::NOT_AN_ARRAY_ITEM => 'Each foo item must be an array'
+            ]
+        ];
+
+        $this->assertEquals($expected, $result->getMessages());
+    }
+
     public function testCanValidateNestedArrays()
     {
         $this->validator->required('foo')->each(function (Validator $validator) {


### PR DESCRIPTION
### What?
`EachRule` didn't handle the case when elements are non-array values.
Because of that the `TypeError` is thrown instead of validation error.

This PR add missing check and throw validation error in that specific case.

### Checklist
- [x] Added unit test for added/fixed code

### PR with bug prove
https://github.com/particle-php/Validator/pull/186