### PR TITLE
Use mb_strlen instead of strlen in Length rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         }
     ],
     "require": {
-        "php": ">=5.4"
+        "php": ">=5.4",
+        "ext-mbstring": "*"
     },
     "suggest": {
         "byrokrat/checkdigit": "If you want to use CreditCard validation rule, this library must be installed.",

--- a/src/Rule/Length.php
+++ b/src/Rule/Length.php
@@ -62,7 +62,7 @@ class Length extends Rule
      */
     public function validate($value)
     {
-        $actualLength = strlen($value);
+        $actualLength = mb_strlen($value);
 
         if ($actualLength > $this->length) {
             return $this->error(self::TOO_LONG);

--- a/src/Rule/LengthBetween.php
+++ b/src/Rule/LengthBetween.php
@@ -69,7 +69,7 @@ class LengthBetween extends Between
      */
     public function validate($value)
     {
-        $length = strlen($value);
+        $length = mb_strlen($value);
 
         return !$this->tooSmall($length, self::TOO_SHORT) && !$this->tooLarge($length, self::TOO_LONG);
     }


### PR DESCRIPTION
### What?
Use `mb_strlen` instead of `strlen` in `Length` rules.