### PR TITLE
Reuseable validator on NotEmpty and Required

### DIFF
--- a/src/Rule/NotEmpty.php
+++ b/src/Rule/NotEmpty.php
@@ -37,7 +37,7 @@ class NotEmpty extends Rule
      *
      * @var bool
      */
-    protected $shouldBreak;
+    protected $shouldBreak = false;
 
     /**
      * Indicates if the value can be empty.
@@ -86,6 +86,7 @@ class NotEmpty extends Rule
      */
     public function validate($value)
     {
+        $this->shouldBreak = false;
         if ($this->isEmpty($value)) {
             $this->shouldBreak = true;
 

--- a/src/Rule/Required.php
+++ b/src/Rule/Required.php
@@ -37,7 +37,7 @@ class Required extends Rule
      *
      * @var bool
      */
-    protected $shouldBreak;
+    protected $shouldBreak = false;
 
     /**
      * Indicates if the value is required.
@@ -99,6 +99,7 @@ class Required extends Rule
     public function isValid($key, Container $input)
     {
         $this->required = $this->isRequired($input);
+        $this->shouldBreak = false;
 
         if (!$input->has($key)) {
             $this->shouldBreak = true;

--- a/tests/ResuableValidatorTest.php
+++ b/tests/ResuableValidatorTest.php
@@ -1,0 +1,110 @@
+<?php
+namespace Particle\Validator\Tests;
+
+use Particle\Validator\Validator;
+
+class ReusableValidatorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Validator
+     */
+    protected $validator;
+
+    protected function configureValidator()
+    {
+        $this->validator = new Validator();
+
+        $this->validator->required('customerNr')->alnum();
+        $this->validator->required('paymentType')->inArray([
+            'downPaymentChangeBankAccount',
+            'downPaymentHighSpend',
+        ]);
+        $this->validator->required('reference')->alnum();
+        $this->validator->required('description')->lengthBetween(1, 250);
+        $this->validator->required('amountPaid')->numeric()->between(0.01, 10000);
+        $this->validator->required('notificationDate')->datetime('Ymd');
+    }
+
+    public function testCanUseNewValidatorEveryTime()
+    {
+        foreach ($this->getTestData() as $testRow) {
+            $this->configureValidator();
+
+            $isValid = $this->validator->validate($testRow['data']);
+
+            $this->assertEquals($testRow['valid'], $isValid);
+            $this->assertEquals($testRow['messages'], $this->validator->getMessages());
+        }
+    }
+
+    public function testCanReuseValidatorMultipleTimes()
+    {
+        $this->configureValidator();
+        foreach ($this->getTestData() as $testRow) {
+            $isValid = $this->validator->validate($testRow['data']);
+
+            $this->assertEquals($testRow['valid'], $isValid);
+            $this->assertEquals($testRow['messages'], $this->validator->getMessages());
+        }
+    }
+
+    private function getTestData()
+    {
+        return [
+            [
+                'data' => [
+                    'customerNr' => 'c000012340',
+                    'paymentType' => '',
+                    'reference' => '',
+                    'description' => 'Test payment 1',
+                    'amountPaid' => 1000.00,
+                    'notificationDate' => '20150401',
+                ],
+                'valid' => false,
+                'messages' => [
+                    'paymentType' => [
+                        'NotEmpty::EMPTY_VALUE' => 'paymentType must not be empty',
+                    ],
+                    'reference' => [
+                        'NotEmpty::EMPTY_VALUE' => 'reference must not be empty',
+                    ],
+                ],
+            ],
+            [
+                'data' => [
+                    'customerNr' => 'c000001234',
+                    'paymentType' => 'gfh',
+                    'reference' => 'dfg',
+                    'description' => 'Test payment 2',
+                    'amountPaid' => 25.00,
+                    'notificationDate' => '20150401',
+                ],
+                'valid' => false,
+                'messages' => [
+                    'paymentType' => [
+                        'InArray::NOT_IN_ARRAY' => 'paymentType must be in the defined set of values',
+                    ],
+                ],
+            ],
+            [
+                'data' => [
+                    'customerNr' => 'c000005678',
+                    'paymentType' => 'sdf ',
+                    'reference' => '',
+                    'description' => 'Test payment 3',
+                    'amountPaid' => 25.00,
+                    'notificationDate' => '20150401',
+                ],
+                'valid' => false,
+                'messages' => [
+                    'paymentType' => [
+                        'InArray::NOT_IN_ARRAY' => 'paymentType must be in the defined set of values',
+                    ],
+                    'reference' => [
+                        'NotEmpty::EMPTY_VALUE' => 'reference must not be empty',
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/ResuableValidatorTest.php
+++ b/tests/ResuableValidatorTest.php
@@ -27,7 +27,7 @@ class ReusableValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testCanUseNewValidatorEveryTime()
     {
-        foreach ($this->getTestData() as $testRow) {
+        foreach ($this->getTestData() as $rowKey => $testRow) {
             $this->configureValidator();
 
             $isValid = $this->validator->validate($testRow['data']);
@@ -40,11 +40,11 @@ class ReusableValidatorTest extends \PHPUnit_Framework_TestCase
     public function testCanReuseValidatorMultipleTimes()
     {
         $this->configureValidator();
-        foreach ($this->getTestData() as $testRow) {
-            $isValid = $this->validator->validate($testRow['data']);
 
-            $this->assertEquals($testRow['valid'], $isValid);
-            $this->assertEquals($testRow['messages'], $this->validator->getMessages());
+        foreach ($this->getTestData() as $rowKey => $testRow) {
+            $isValid = $this->validator->validate($testRow['data']);
+            $this->assertEquals($testRow['valid'], $isValid, 'Row ' . $rowKey . ' wasn\'t expected');
+            $this->assertEquals($testRow['messages'], $this->validator->getMessages(), 'Row ' . $rowKey . ' wasn\'t expected');
         }
     }
 
@@ -70,6 +70,7 @@ class ReusableValidatorTest extends \PHPUnit_Framework_TestCase
                     ],
                 ],
             ],
+
             [
                 'data' => [
                     'customerNr' => 'c000001234',

--- a/tests/ResuableValidatorTest.php
+++ b/tests/ResuableValidatorTest.php
@@ -43,8 +43,8 @@ class ReusableValidatorTest extends \PHPUnit_Framework_TestCase
 
         foreach ($this->getTestData() as $rowKey => $testRow) {
             $isValid = $this->validator->validate($testRow['data']);
-            $this->assertEquals($testRow['valid'], $isValid, 'Row ' . $rowKey . ' wasn\'t expected');
-            $this->assertEquals($testRow['messages'], $this->validator->getMessages(), 'Row ' . $rowKey . ' wasn\'t expected');
+            $this->assertEquals($testRow['valid'], $isValid);
+            $this->assertEquals($testRow['messages'], $this->validator->getMessages());
         }
     }
 

--- a/tests/ResuableValidatorTest.php
+++ b/tests/ResuableValidatorTest.php
@@ -75,7 +75,6 @@ class ReusableValidatorTest extends \PHPUnit_Framework_TestCase
                 'data' => [
                     'customerNr' => 'c000001234',
                     'paymentType' => 'gfh',
-                    'reference' => 'dfg',
                     'description' => 'Test payment 2',
                     'amountPaid' => 25.00,
                     'notificationDate' => '20150401',
@@ -84,6 +83,9 @@ class ReusableValidatorTest extends \PHPUnit_Framework_TestCase
                 'messages' => [
                     'paymentType' => [
                         'InArray::NOT_IN_ARRAY' => 'paymentType must be in the defined set of values',
+                    ],
+                    'reference' => [
+                        'Required::NON_EXISTENT_KEY' => 'reference must be provided, but does not exist',
                     ],
                 ],
             ],


### PR DESCRIPTION
### What?

We've added a testcase because Stefan (can't tag him) noticed an issue in the validator.

It looks like the shouldBreak variable in the NotEmpty rule gets changed on validate, but is never initialized, thus not reset.

This change is for V1.0.6 because we need it to run in PHP5.6 - I'll see if the problems also exists in V2

### Checklist

- [X] Added unit test for added/fixed code
- [ ] Updated the documentation
- [X] Scrutinizer code coverage is 100%
- [X] Scrutinizer code quality is as high as possible