### PR TITLE
Reuseable validator on NotEmpty & IsRequired [ v2 ]

### DIFF
--- a/src/Rule/NotEmpty.php
+++ b/src/Rule/NotEmpty.php
@@ -40,7 +40,7 @@ class NotEmpty extends Rule
      *
      * @var bool
      */
-    protected $shouldBreak;
+    protected $shouldBreak = false;
 
     /**
      * Indicates if the value can be empty.
@@ -89,6 +89,7 @@ class NotEmpty extends Rule
      */
     public function validate($value)
     {
+        $this->shouldBreak = false;
         if ($this->isEmpty($value)) {
             $this->shouldBreak = true;
 

--- a/src/Rule/Required.php
+++ b/src/Rule/Required.php
@@ -40,7 +40,7 @@ class Required extends Rule
      *
      * @var bool
      */
-    protected $shouldBreak;
+    protected $shouldBreak = false;
 
     /**
      * Indicates if the value is required.
@@ -101,6 +101,7 @@ class Required extends Rule
      */
     public function isValid($key, Container $input)
     {
+        $this->shouldBreak = false;
         $this->required = $this->isRequired($input);
 
         if (!$input->has($key)) {

--- a/tests/ReusableValidatorTest.php
+++ b/tests/ReusableValidatorTest.php
@@ -74,7 +74,6 @@ class ReusableValidatorTest extends \PHPUnit_Framework_TestCase
                 'data' => [
                     'customerNr' => 'c000001234',
                     'paymentType' => 'gfh',
-                    'reference' => 'dfg',
                     'description' => 'Test payment 2',
                     'amountPaid' => 25.00,
                     'notificationDate' => '20150401',
@@ -83,6 +82,9 @@ class ReusableValidatorTest extends \PHPUnit_Framework_TestCase
                 'messages' => [
                     'paymentType' => [
                         'InArray::NOT_IN_ARRAY' => 'paymentType must be in the defined set of values',
+                    ],
+                    'reference' => [
+                        'Required::NON_EXISTENT_KEY' => 'reference must be provided, but does not exist',
                     ],
                 ],
             ],

--- a/tests/ReusableValidatorTest.php
+++ b/tests/ReusableValidatorTest.php
@@ -1,0 +1,110 @@
+<?php
+namespace Particle\Validator\Tests;
+
+use Particle\Validator\Validator;
+
+class ReusableValidatorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Validator
+     */
+    protected $validator;
+
+    protected function configureValidator()
+    {
+        $this->validator = new Validator();
+
+        $this->validator->required('customerNr')->alnum();
+        $this->validator->required('paymentType')->inArray([
+            'downPaymentChangeBankAccount',
+            'downPaymentHighSpend',
+        ]);
+        $this->validator->required('reference')->alnum();
+        $this->validator->required('description')->lengthBetween(1, 250);
+        $this->validator->required('amountPaid')->float()->between(0.01, 10000);
+        $this->validator->required('notificationDate')->datetime('Ymd');
+    }
+
+    public function testCanUseNewValidatorEveryTime()
+    {
+        foreach ($this->getTestData() as $rowKey => $testRow) {
+            $this->configureValidator();
+
+            $result = $this->validator->validate($testRow['data']);
+            $this->assertEquals($testRow['valid'], $result->isValid());
+            $this->assertEquals($testRow['messages'], $result->getMessages());
+        }
+    }
+
+    public function testCanReuseValidatorMultipleTimes()
+    {
+        $this->configureValidator();
+
+        foreach ($this->getTestData() as $rowKey => $testRow) {
+            $result = $this->validator->validate($testRow['data']);
+            $this->assertEquals($testRow['valid'], $result->isValid());
+            $this->assertEquals($testRow['messages'], $result->getMessages());
+        }
+    }
+
+    private function getTestData()
+    {
+        return [
+            [
+                'data' => [
+                    'customerNr' => 'c000012340',
+                    'paymentType' => '',
+                    'reference' => '',
+                    'description' => 'Test payment 1',
+                    'amountPaid' => 1000.00,
+                    'notificationDate' => '20150401',
+                ],
+                'valid' => false,
+                'messages' => [
+                    'paymentType' => [
+                        'NotEmpty::EMPTY_VALUE' => 'paymentType must not be empty',
+                    ],
+                    'reference' => [
+                        'NotEmpty::EMPTY_VALUE' => 'reference must not be empty',
+                    ],
+                ],
+            ],
+
+            [
+                'data' => [
+                    'customerNr' => 'c000001234',
+                    'paymentType' => 'gfh',
+                    'reference' => 'dfg',
+                    'description' => 'Test payment 2',
+                    'amountPaid' => 25.00,
+                    'notificationDate' => '20150401',
+                ],
+                'valid' => false,
+                'messages' => [
+                    'paymentType' => [
+                        'InArray::NOT_IN_ARRAY' => 'paymentType must be in the defined set of values',
+                    ],
+                ],
+            ],
+            [
+                'data' => [
+                    'customerNr' => 'c000005678',
+                    'paymentType' => 'sdf ',
+                    'reference' => '',
+                    'description' => 'Test payment 3',
+                    'amountPaid' => 25.00,
+                    'notificationDate' => '20150401',
+                ],
+                'valid' => false,
+                'messages' => [
+                    'paymentType' => [
+                        'InArray::NOT_IN_ARRAY' => 'paymentType must be in the defined set of values',
+                    ],
+                    'reference' => [
+                        'NotEmpty::EMPTY_VALUE' => 'reference must not be empty',
+                    ],
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
### What?

Same fix as https://github.com/particle-php/Validator/pull/191 but for v2 

### Checklist

- [X] Added unit test for added/fixed code
- [ ] Updated the documentation
- [X] Scrutinizer code coverage is 100%
- [X] Scrutinizer code quality is as high as possible