### PR TITLE
Update Validator.php

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -112,7 +112,7 @@ class Validator
      * @param callable|null $callback
      * @return $this
      */
-    public function copyContext($otherContext, callable $callback = null)
+    public function copyContext($otherContext, ?callable $callback = null)
     {
         $this->copyChains($otherContext, $callback);
         if ($otherContext !== self::DEFAULT_CONTEXT) {


### PR DESCRIPTION
```
PHP Deprecated:  Particle\Validator\Validator::copyContext(): Implicitly marking parameter $callback as nullable is deprecated, the explicit nullable type must be used instead in /var/www/localhost/htdocs/openemr/vendor/particle/validator/src/Validator.php on line 115

### What?

description

### Checklist

- [ ] Added unit test for added/fixed code
- [ ] Updated the documentation
- [ ] Scrutinizer code coverage is 100%
- [ ] Scrutinizer code quality is as high as possible

### Linked issue

link
